### PR TITLE
Fix set-url-new-buffer duplicate

### DIFF
--- a/next/source/base.lisp
+++ b/next/source/base.lisp
@@ -53,7 +53,7 @@
     ;; We can have many urls as positional arguments.
     (if free-args
         (loop for url in free-args do
-             (set-url-new-buffer url t))
+             (%set-url-new-buffer url t))
         (set-url *start-page-url*))))
 
 (defun initialize-default-key-bindings ()

--- a/next/source/document-mode.lisp
+++ b/next/source/document-mode.lisp
@@ -132,7 +132,7 @@ buffer"
     (history-typed-add input-url))
   (interface:web-view-set-url (view buffer) input-url))
 
-(defun set-url-new-buffer (input-url &optional disable-history)
+(defun %set-url-new-buffer (input-url &optional disable-history)
   (let ((new-buffer (generate-new-buffer "default" (document-mode))))
     (set-visible-active-buffer new-buffer)
     (set-url-buffer input-url new-buffer disable-history)))


### PR DESCRIPTION
SET-URL-NEW-BUFFER is declared twice which is probably a bug and also leads to
compilation warning/error on some Common Lisp implementations.