### PR TITLE
fix gtk-entry-text not external to gtk package

### DIFF
--- a/next/source/gtk/gtk.lisp
+++ b/next/source/gtk/gtk.lisp
@@ -33,7 +33,7 @@
         (write-to-string element))))
 
 (defmethod get-input ((self minibuffer-view))
-  (gtk:gtk-entry-text (input-entry self)))
+  (gtk::gtk-entry-text (input-entry self)))
 
 (defmethod process-set-completions ((self minibuffer-view))
   "Process and set completions for the minibuffer"


### PR DESCRIPTION
I am on Quicklisp "2018-04-30", if that makes a difference.

a `make build-gtk` was failing due to this.