### PR TITLE
Fix nil path.

### DIFF
--- a/source/gtk/gtk.lisp
+++ b/source/gtk/gtk.lisp
@@ -246,11 +246,11 @@
 
 (defun minibuffer-get-input-complete ()
   (with-slots (completion-view completions) (minibuffer-view *next-interface*)
-    (let ((path (gtk:gtk-tree-path-to-string
-                 (gtk:gtk-tree-view-get-cursor completion-view))))
-      (if path
-          (nth (parse-integer path) completions)
-          nil))))
+    (let ((cursor (gtk:gtk-tree-view-get-cursor completion-view)))
+      (when cursor
+        (let ((path (gtk:gtk-tree-path-to-string cursor)))
+          (when path
+            (nth (parse-integer path) completions)))))))
 
 (defun minibuffer-select-next ()
   (gtk:gtk-tree-view-set-cursor


### PR DESCRIPTION
- Fixes one case of a null value being passed to a tree path function, that's only visible on stdout.
- Cleaner main loop handling; this might a bit of explanation: `within-main-loop` will always add one more level of nesting for the Lisp side handling of the main loop (via `ensure-gtk-main`) and thus needs to match the number of invocations for `leave-gtk-main` (eventually, the last one would terminate the main loop and the program). Therefore, this change makes the macro use `within-gtk-thread`, which we've added exactly for this reason, to just ensure a function is executed in the main loop thread, but without further nesting. For the built image there's no change, for interactive development you might want to ensure you always have one level of nesting left, so before the main window is closed again, use `ensure-gtk-main` and observe that second return value should be 2 (but not much more than that). When the window is then closed, the GTK main thread is still kept alive, with nesting level 1 and `(start)` could be called again (increasing the level back to two). I've also seen a crash (in the WebKit part probably) when the main thread was completely killed and then restarted via `start`, that's why I'm suggesting leaving the main thread alive.
- Stored the main window in a variable, basically just to be able to remove it later, that makes for a bit nicer experience with interactive development as the window doesn't stay around when it was supposed to be closed.
- One of the `destroy` handlers was duplicated, so would've called `leave-gtk-main` more often than necessary.