### PR TITLE
warn about error loading the init file and don't fail

### DIFF
--- a/source/base.lisp
+++ b/source/base.lisp
@@ -81,7 +81,10 @@ Set to '-' to read standard input instead."))
         (loop for object = (read *standard-input* nil :eof)
               until (eq object :eof)
               do (eval object)))
-      (load *init-file-path* :if-does-not-exist nil))
+      ;; ignore loading errors
+      (handler-case (load *init-file-path* :if-does-not-exist nil)
+        (error (c)
+          (format t "Error: we could not load your init file: ~a~&" c))))
   (initialize-bookmark-db)
   (initialize-history-db)
   (when with-platform-port-p


### PR DESCRIPTION
Next failed to start because of an error in my `init.lisp`, which was working with the previous version (the command used `(interface:web-view-get-url …`).

This addition catches all errors so than Next can start. Or should it fail, or warn the user in the interface ?

disclaimer: I couldn't test it !! (I still don't have a working installation)