### PR TITLE
Add visits column to typed history, and sort by it

### DIFF
--- a/next.asd
+++ b/next.asd
@@ -7,7 +7,8 @@
   :license "BSD 3-Clause"
   :serial t
   :defsystem-depends-on ("trivial-features")
-  :depends-on (:alexandria
+  :depends-on (:anaphora
+               :alexandria
                :cl-strings
                :cl-string-match
                :puri

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -18,26 +18,31 @@
      db "insert into typed (url) values (?)" "about:blank")
     (sqlite:disconnect db)))
 
+(defun ensure-history-db ()
+  "Returns the pathname of the history database"
+  (ensure-file-exists 
+   (anaphora:aif (window-active *interface*)
+                 (history-db-path anaphora:it)
+                 ;;; FIXME: when we want to have multiple history-db
+                 (some (lambda (window)
+                         (history-db-path window))
+                       (alexandria:hash-table-values (windows *interface*))))
+   #'%initialize-history-db))
+       
 (defun history-add (url)
-  (let ((db (sqlite:connect
-             (ensure-file-exists (history-db-path (window-active *interface*))
-                                 #'%initialize-history-db))))
+  (let ((db (sqlite:connect (ensure-history-db))))
     (sqlite:execute-non-query
      db "insert into history (url) values (?)" url)
     (sqlite:disconnect db)))
 
 (defun history-typed-add (url)
-  (let ((db (sqlite:connect
-             (ensure-file-exists (history-db-path (window-active *interface*))
-                                 #'%initialize-history-db))))
+  (let ((db (sqlite:connect (ensure-history-db))))
     (sqlite:execute-non-query
      db "insert into typed (url) values (?)" url)
     (sqlite:disconnect db)))
 
 (defun history-typed-complete (input)
-  (let* ((db (sqlite:connect
-              (ensure-file-exists (history-db-path (window-active *interface*))
-                                  #'%initialize-history-db)))
+  (let* ((db (sqlite:connect (ensure-history-db)))
          (candidates
           (sqlite:execute-to-list
            db "select url from typed where url like ?"


### PR DESCRIPTION
This will add a visits column to new databases, as well as ones that already exists. It's incremented on each visit to the url, and it is used to sort the history so the things you visit often come first.