### PR TITLE
Add space to cursor-forwards-word and cursor-backwards-word

### DIFF
--- a/next.asd
+++ b/next.asd
@@ -7,7 +7,8 @@
   :license "BSD 3-Clause"
   :serial t
   :defsystem-depends-on ("trivial-features")
-  :depends-on (:alexandria
+  :depends-on (:anaphora
+               :alexandria
                :cl-strings
                :cl-string-match
                :puri

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -18,26 +18,31 @@
      db "insert into typed (url) values (?)" "about:blank")
     (sqlite:disconnect db)))
 
+(defun ensure-history-db ()
+  "Returns the pathname of the history database"
+  (ensure-file-exists 
+   (anaphora:aif (window-active *interface*)
+                 (history-db-path anaphora:it)
+                 ;;; FIXME: when we want to have multiple history-db
+                 (some (lambda (window)
+                         (history-db-path window))
+                       (alexandria:hash-table-values (windows *interface*))))
+   #'%initialize-history-db))
+       
 (defun history-add (url)
-  (let ((db (sqlite:connect
-             (ensure-file-exists (history-db-path (window-active *interface*))
-                                 #'%initialize-history-db))))
+  (let ((db (sqlite:connect (ensure-history-db))))
     (sqlite:execute-non-query
      db "insert into history (url) values (?)" url)
     (sqlite:disconnect db)))
 
 (defun history-typed-add (url)
-  (let ((db (sqlite:connect
-             (ensure-file-exists (history-db-path (window-active *interface*))
-                                 #'%initialize-history-db))))
+  (let ((db (sqlite:connect (ensure-history-db))))
     (sqlite:execute-non-query
      db "insert into typed (url) values (?)" url)
     (sqlite:disconnect db)))
 
 (defun history-typed-complete (input)
-  (let* ((db (sqlite:connect
-              (ensure-file-exists (history-db-path (window-active *interface*))
-                                  #'%initialize-history-db)))
+  (let* ((db (sqlite:connect (ensure-history-db)))
          (candidates
           (sqlite:execute-to-list
            db "select url from typed where url like ?"

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -240,7 +240,7 @@
         (char (input-buffer minibuffer) (input-buffer-cursor minibuffer)))))
 
 (defun cursor-forwards-word (&optional (minibuffer (minibuffer *interface*)))
-  (let ((stop-characters '(#\: #\/ #\- #\.)))
+  (let ((stop-characters '(#\: #\/ #\- #\. #\Space)))
     (with-slots (input-buffer input-buffer-cursor) minibuffer
       (if (intersection stop-characters (list (char-at-cursor minibuffer)))
           (loop while (and
@@ -256,7 +256,7 @@
 
 ;; TODO: Re-use cursor-forwards-word
 (defun cursor-backwards-word (&optional (minibuffer (minibuffer *interface*)))
-  (let ((stop-characters '(#\: #\/ #\- #\.)))
+  (let ((stop-characters '(#\: #\/ #\- #\. #\Space)))
     (with-slots (input-buffer input-buffer-cursor) minibuffer
       (if (intersection stop-characters (list (char-at-cursor minibuffer)))
           (loop while (and


### PR DESCRIPTION
This seems like something that should have already been there, but if not feel free to say why space was not included in the `cursor-backwards-word` and `cursor-forwards-word` functions. Also a little question, do you happen to have an IRC you guys hang out on?