### PR TITLE
Add *search-engines* alist for defining search engines

### DIFF
--- a/next.asd
+++ b/next.asd
@@ -7,7 +7,8 @@
   :license "BSD 3-Clause"
   :serial t
   :defsystem-depends-on ("trivial-features")
-  :depends-on (:alexandria
+  :depends-on (:anaphora
+               :alexandria
                :cl-strings
                :cl-string-match
                :puri

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -35,10 +35,11 @@
 (defvar *package-globals* nil
   "The package global variables available, populated by helper
   function load package-globals")
-(defvar *search-engines* '(("default" . "https://duckduckgo.com/?q=")
-                           ("wiki" . "https://en.wikipedia.org/w/index.php?search="))
+(defvar *search-engines* '(("default" . "https://duckduckgo.com/?q=~a")
+                           ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a"))
   "An association list of all the search engines you can use in the minibuffer.
-The 'default' engine is use for searching with 's' and as a backup.")
+The 'default' engine is use when the query is not a valid URL, or the first
+keyword is not recognised.")
 
 (defparameter +version+
   (let ((version (asdf/component:component-version (asdf:find-system :next)))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -35,6 +35,10 @@
 (defvar *package-globals* nil
   "The package global variables available, populated by helper
   function load package-globals")
+(defvar *search-engines* '(("default" . "https://duckduckgo.com/?q=")
+                           ("wiki" . "https://en.wikipedia.org/w/index.php?search="))
+  "An association list of all the search engines you can use in the minibuffer.
+The 'default' engine is use for searching with 's' and as a backup.")
 
 (defparameter +version+
   (let ((version (asdf/component:component-version (asdf:find-system :next)))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -35,11 +35,6 @@
 (defvar *package-globals* nil
   "The package global variables available, populated by helper
   function load package-globals")
-(defvar *search-engines* '(("default" . "https://duckduckgo.com/?q=~a")
-                           ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a"))
-  "An association list of all the search engines you can use in the minibuffer.
-The 'default' engine is use when the query is not a valid URL, or the first
-keyword is not recognised.")
 
 (defparameter +version+
   (let ((version (asdf/component:component-version (asdf:find-system :next)))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -18,26 +18,31 @@
      db "insert into typed (url) values (?)" "about:blank")
     (sqlite:disconnect db)))
 
+(defun ensure-history-db ()
+  "Returns the pathname of the history database"
+  (ensure-file-exists 
+   (anaphora:aif (window-active *interface*)
+                 (history-db-path anaphora:it)
+                 ;;; FIXME: when we want to have multiple history-db
+                 (some (lambda (window)
+                         (history-db-path window))
+                       (alexandria:hash-table-values (windows *interface*))))
+   #'%initialize-history-db))
+       
 (defun history-add (url)
-  (let ((db (sqlite:connect
-             (ensure-file-exists (history-db-path (window-active *interface*))
-                                 #'%initialize-history-db))))
+  (let ((db (sqlite:connect (ensure-history-db))))
     (sqlite:execute-non-query
      db "insert into history (url) values (?)" url)
     (sqlite:disconnect db)))
 
 (defun history-typed-add (url)
-  (let ((db (sqlite:connect
-             (ensure-file-exists (history-db-path (window-active *interface*))
-                                 #'%initialize-history-db))))
+  (let ((db (sqlite:connect (ensure-history-db))))
     (sqlite:execute-non-query
      db "insert into typed (url) values (?)" url)
     (sqlite:disconnect db)))
 
 (defun history-typed-complete (input)
-  (let* ((db (sqlite:connect
-              (ensure-file-exists (history-db-path (window-active *interface*))
-                                  #'%initialize-history-db)))
+  (let* ((db (sqlite:connect (ensure-history-db)))
          (candidates
           (sqlite:execute-to-list
            db "select url from typed where url like ?"

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -17,7 +17,12 @@
    (history-db-path :accessor history-db-path :initform (xdg-data-home "history.db")
                     :documentation "The path where the system will create/save the history database.")
    (bookmark-db-path :accessor bookmark-db-path :initform (xdg-data-home "bookmark.db")
-                     :documentation "The path where the system will create/save the bookmark database.")))
+                     :documentation "The path where the system will create/save the bookmark database.")
+   (search-engines :accessor search-engines :initform '(("default" . "https://duckduckgo.com/?q=~a")
+                                                        ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a"))
+                   :documentation "An association list of all the search engines you can use in the minibuffer.
+The 'default' engine is use when the query is not a valid URL, or the first
+keyword is not recognized.")))
 
 (defclass buffer ()
   ((id :accessor id :initarg :id)

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -27,10 +27,11 @@ slime. Default port is 4006."
   (swank:create-server :port *swank-port* :dont-close t))
 
 (defun parse-url (input-url)
-  (let ((engine (assoc (first (cl-strings:split input-url))
-                       *search-engines* :test #'string=))
-        (default (assoc "default"
-                        *search-engines* :test #'string=)))
+  (let* ((window (window-active *interface*))
+         (engine (assoc (first (cl-strings:split input-url))
+                       (search-engines window) :test #'string=))
+         (default (assoc "default"
+                         (search-engines window) :test #'string=)))
     (if engine
         (generate-search-query (subseq input-url
                                        (length (first (cl-strings:split input-url))))

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -33,9 +33,10 @@ slime. Default port is 4006."
          (default (assoc "default"
                          (search-engines window) :test #'string=)))
     (if engine
-        (generate-search-query (subseq input-url
-                                       (length (first (cl-strings:split input-url))))
-                               (cdr engine))
+        (generate-search-query
+         (subseq input-url
+                 (length (first (cl-strings:split input-url))))
+         (cdr engine))
       (handler-case
           ;; puri:parse-uri fails on crazy inputs like:
           ;; - hello world

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -45,8 +45,7 @@ slime. Default port is 4006."
              ((probe-file input-url)
               (concatenate 'string "file://" input-url))
              (t (generate-search-query input-url (cdr default)))))
-        (puri:uri-parse-error ()
-                              input-url)))))
+        (puri:uri-parse-error () input-url)))))
 
 (defun generate-search-query (search-string search-url)
   (let* ((encoded-search-string

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -27,23 +27,33 @@ slime. Default port is 4006."
   (swank:create-server :port *swank-port* :dont-close t))
 
 (defun parse-url (input-url)
-  (handler-case
-      ;; puri:parse-uri fails on crazy inputs like:
-      ;; - hello world
-      ;; - https://www.google.com/search?q=hello world
-      (let ((url (puri:parse-uri input-url)))
-        (cond
-          ((puri:uri-scheme url) input-url)
-          ((probe-file input-url)
-           (concatenate 'string "file://" input-url))
-          (t (generate-search-query input-url))))
-    (puri:uri-parse-error ()
-      input-url)))
+  (let ((engine (assoc (nth 0 (cl-strings:split input-url))
+                       *search-engines* :test #'string=))
+        (default (assoc "default"
+                        *search-engines* :test #'string=)))
+    (if engine
+        (generate-search-query (subseq input-url
+                                       (length (nth 0 (cl-strings:split input-url))))
+                               (cdr engine))
+      (if (string= "s" (nth 0 (cl-strings:split input-url)))
+          (generate-search-query (subseq input-url 2) (cdr default))
+        (handler-case
+            ;; puri:parse-uri fails on crazy inputs like:
+            ;; - hello world
+            ;; - https://www.google.com/search?q=hello world
+            (let ((url (puri:parse-uri input-url)))
+              (cond
+               ((puri:uri-scheme url) input-url)
+               ((probe-file input-url)
+                (concatenate 'string "file://" input-url))
+               (t (generate-search-query input-url (cdr default)))))
+          (puri:uri-parse-error ()
+                                input-url))))))
 
-(defun generate-search-query (search-string)
+(defun generate-search-query (search-string search-url)
   (let* ((encoded-search-string
            (cl-string-match:replace-re "  *" "+" search-string :all t))
-         (url (concatenate 'string "https://duckduckgo.com/?q=" encoded-search-string)))
+         (url (concatenate 'string search-url encoded-search-string)))
     url))
 
 (defun fuzzy-match (input candidates &key (accessor-function nil)


### PR DESCRIPTION
This adds as association list that the user can fill with short names plus a search url to use for searching in the minibuffer. This also brings back the searching with s, but allows the user to set it in the alist by changing the 'default' key.

I wasn't sure if this is the kind of feature you wanted after I saw that searching with s was removed, but I've had this feature in other web browsers in the past and find it quite useful.