### PR TITLE
command.lisp: define-command - typo in docstring

### DIFF
--- a/source/command.lisp
+++ b/source/command.lisp
@@ -19,7 +19,7 @@
 
 (defmacro define-command (name (&optional (mode 'root-mode) &rest arglist) &body body)
   "Define new command NAME.
-MODE most be a subclass of root-mode.
+MODE must be a subclass of root-mode.
 ARGLIST must be a list of optional arguments."
   (let ((documentation (if (stringp (first body))
                            (first body)


### PR DESCRIPTION
Fix a minor typo on define-command docstring.

PS: I've seen a "]" in some of the **/source** files...I reckon someone fixed it already.