### PR TITLE
Titlecase

### DIFF
--- a/ports/gtk-webkit/buffer.h
+++ b/ports/gtk-webkit/buffer.h
@@ -16,7 +16,7 @@ typedef struct {
 
 // See the documentation of "enum GdkModifierType".
 static Modifier modifier_names[] = {
-	{.mod = GDK_SHIFT_MASK, .name = "s"},
+	{.mod = GDK_SHIFT_MASK, .name = "Shift"},
 	{.mod = GDK_LOCK_MASK, .name = "Lock"},
 	{.mod = GDK_CONTROL_MASK, .name = "C"},
 	{.mod = GDK_MOD1_MASK, .name = "M"}, // Usually "Alt".

--- a/ports/gtk-webkit/buffer.h
+++ b/ports/gtk-webkit/buffer.h
@@ -208,7 +208,7 @@ gboolean buffer_web_view_decide_policy(WebKitWebView *_web_view,
 	gchar *mouse_button = "";
 	if (action) {
 		guint button = webkit_navigation_action_get_mouse_button(action);
-		mouse_button = g_strdup_printf("button%d", button);
+		mouse_button = g_strdup_printf("Button%d", button);
 
 		guint modifiers = webkit_navigation_action_get_modifiers(action);
 		for (int i = 0; i < (sizeof modifier_names)/(sizeof modifier_names[0]); i++) {

--- a/ports/gtk-webkit/window.h
+++ b/ports/gtk-webkit/window.h
@@ -19,13 +19,13 @@ typedef struct {
 } KeyTranslation;
 
 static KeyTranslation key_translations[] = {
-	{.old = "", .new = "BACKSPACE"},
-	{.old = " ", .new = "SPACE"},
-	{.old = "", .new = "DELETE"},
-	{.old = "-", .new = "HYPHEN"},
-	{.old = "", .new = "ESCAPE"},
-	{.old = "\r", .new = "RETURN"},
-	{.old = "\t", .new = "TAB"},
+	{.old = "", .new = "Backspace"},
+	{.old = " ", .new = "Space"},
+	{.old = "", .new = "Delete"},
+	{.old = "-", .new = "Hyphen"},
+	{.old = "", .new = "Escape"},
+	{.old = "\r", .new = "Return"},
+	{.old = "\t", .new = "Tab"},
 };
 
 guint window_string_to_modifier(gchar *s) {
@@ -421,7 +421,7 @@ gboolean window_button_event(GtkWidget *_widget, GdkEventButton *event, gpointer
 		}
 	}
 
-	gchar *event_string = g_strdup_printf("button%d", event->button);
+	gchar *event_string = g_strdup_printf("Button%d", event->button);
 	return window_send_event(window,
 		       event_string, event->state,
 		       0, event->button,
@@ -487,7 +487,7 @@ gboolean window_scroll_event(GtkWidget *_widget, GdkEventScroll *event, gpointer
 	}
 	}
 
-	gchar *event_string = g_strdup_printf("button%d", button);
+	gchar *event_string = g_strdup_printf("Button%d", button);
 	return window_send_event(window,
 		       event_string, event->state,
 		       event->direction, button,

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -68,7 +68,7 @@
           "C-f" 'scroll-page-down
           "C-b" 'scroll-page-up
           "SPACE" 'scroll-page-down
-          "s-SPACE" 'scroll-page-up)
+          "Shift-SPACE" 'scroll-page-up)
         (list :emacs emacs-map
               :vi-normal vi-map))))
   ;; Init.

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -19,12 +19,12 @@
           "C-x C-w" 'copy-anchor-url
           "C-f" 'history-forwards
           "C-b" 'history-backwards
-          "button9" 'history-forwards
-          "button8" 'history-backwards
+          "Button9" 'history-forwards
+          "Button8" 'history-backwards
           "C-p" 'scroll-up
           "C-n" 'scroll-down
           "C-x C-=" 'zoom-in-page
-          "C-x C-HYPHEN" 'zoom-out-page
+          "C-x C-Hyphen" 'zoom-out-page
           "C-x C-0" 'unzoom-page
           "C-r" 'reload-current-buffer
           "C-m o" 'set-url-from-bookmark
@@ -48,8 +48,8 @@
           "f" 'go-anchor
           "F" 'go-anchor-new-buffer-focus
           "; f" 'go-anchor-new-buffer
-          "button9" 'history-forwards
-          "button8" 'history-backwards
+          "Button9" 'history-forwards
+          "Button8" 'history-backwards
           "j" 'scroll-down
           "k" 'scroll-up
           "z i" 'zoom-in-page
@@ -67,8 +67,8 @@
           "g g" 'scroll-to-top
           "C-f" 'scroll-page-down
           "C-b" 'scroll-page-up
-          "SPACE" 'scroll-page-down
-          "Shift-SPACE" 'scroll-page-up)
+          "Space" 'scroll-page-down
+          "Shift-Space" 'scroll-page-up)
         (list :emacs emacs-map
               :vi-normal vi-map))))
   ;; Init.

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -8,26 +8,26 @@
      (keymap-schemes
       :initform
       (let ((map (make-keymap)))
-        (define-key "HYPHEN" #'self-insert
-          "SPACE" #'self-insert
+        (define-key "Hyphen" #'self-insert
+          "Space" #'self-insert
           "C-f" #'cursor-forwards
           "M-f" #'cursor-forwards-word
           "C-b" #'cursor-backwards
           "M-b" #'cursor-backwards-word
           "M-d" #'delete-forwards-word
-          "M-BACKSPACE" #'delete-backwards-word
+          "M-Backspace" #'delete-backwards-word
           "Right" #'cursor-forwards
           "Left" #'cursor-backwards
           "C-d" #'delete-forwards
-          "DELETE" #'delete-forwards
-          "BACKSPACE" #'delete-backwards
+          "Delete" #'delete-forwards
+          "Backspace" #'delete-backwards
           "C-a" #'cursor-beginning
           "C-e" #'cursor-end
           "C-k" #'kill-line
-          "RETURN" #'return-input
-          "C-RETURN" #'return-immediate
+          "Return" #'return-input
+          "C-Return" #'return-immediate
           "C-g" #'cancel-input
-          "ESCAPE" #'cancel-input
+          "Escape" #'cancel-input
           "C-n" #'select-next
           "C-p" #'select-previous
           "Down" #'select-next
@@ -35,7 +35,7 @@
           "C-v" #'paste
           "C-y" #'paste
           "C-w" #'copy-candidate
-          "TAB" #'insert-candidate
+          "Tab" #'insert-candidate
           :keymap map)
         (list :emacs map
               :vi-normal map
@@ -198,11 +198,12 @@
 (define-command self-insert (minibuffer-mode)
   "Insert key-chord-stack in MINIBUFFER."
   (let ((key-string (key-chord-key-string (first (key-chord-stack *interface*))))
-        (translation-table '(("HYPHEN" "-")
+        (translation-table '(("Hyphen" "-")
                              ;; Regular spaces are concatenated into a single
                              ;; one by HTML rendering, so we use a non-breaking
                              ;; space to avoid confusing the user.
-                             ("SPACE" " "))))
+                             ;; TODO: We should type-check those names.
+                             ("Space" " "))))
     (setf key-string (or (cadr (assoc key-string translation-table :test #'string=))
                          key-string))
     (insert key-string)))

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -9,7 +9,7 @@
       (let ((map (make-keymap)))
         (define-key
           "i" 'vi-insert-mode
-          "button1" 'vi-button1
+          "Button1" 'vi-button1
           :keymap map)
         (list :vi-normal map)))
      (destructor
@@ -33,8 +33,8 @@
       :initform
       (let ((map (make-keymap)))
         (define-key :keymap map
-          "ESCAPE" 'vi-normal-mode
-          "button1" 'vi-button1)
+          "Escape" 'vi-normal-mode
+          "Button1" 'vi-button1)
         (list :vi-insert map)))
      (destructor
       :initform


### PR DESCRIPTION
I've renamed the `s` modifier to `Shift`, and while I was at it, I thought it would be nice to enforce consistency.

This brings up some questions:
- Do you people like titlecase for special keys?  Lowercase would be more Lispy.
- We lack type-checking when it comes to the special key names.  For instance binding "shit-Return" won't raise an error and the user might stay befuddled until they figure they forgot the "f". Can we do something about it?

Regarding the last question, well, we've used strings to encode key-chord, but should we?  We did it this way so far taking inspiration from Emacs / StumpWM, but we don't have to.  In fact, this is Lisp, so why not leveraging the language?  We could use some nifty macros to encode keycodes.  Some examples:

- "a" -> (a)
- "a b" -> (a b)
- "Return" -> (return)
- "Dummy" -> (dummy) ; can error out at macro-expansion time
- "C-x s" -> `((c x) s)`
- "C-M-s" -> `((c (m s)))`

Basically a key binding is a list of symbols.
Symbols are lookep up in a map.  If it does not exist and is a single character, insert this character.
In a sublist, the first character is a modifier.  Sublists can be nested, which enables us to stack modifiers.

We could even encode timeouts, for instance to bind a quick "j k" to vi-normal-mode:
`((timeout j 0.2) k)`, where 0.2 is the timeout in seconds.

And that's the beauty of it: we would be able to extend this mini-language while remaining backward-compatible.  Something that's way harder to do with strings.

And this brings us back to the topic of this PR: if we adopt a Lispy syntax to encode bindings, then should we still use titlecase?

@vindarel @jmercouris 

Edit: s/compile/macro-expansion/