### PR TITLE
Bookmark: rename function, binds semantic, add table to manual.org

### DIFF
--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -219,16 +219,20 @@ forward command will simply visit the first child of the current node
 in the tree.
 
 ** Bookmarks
-Bookmarks are stored in a database located in
-=~/.local/share/next/bookmark.db= by default. This (SQLite) database contains
-one table with two columns: id, url. In order to navigate and manage your
-bookmarks, a few functions are provided:
+   Next bookmarks are stored in a database file located in =~/.local/share/next/bookmark.db=
+   by default.
 
-1. ~C-m k~: Delete Bookmark
-2. ~C-m o~: Open Bookmark
-3. ~C-m s~: Bookmark Current Page
-4. ~C-m u~: Bookmark URL (input URL via minibuffer)
-5. ~C-m g~: Bookmark Anchor (input URL via link hints)
+   This, SQLite, database contains one table with two columns: id, url.
+
+   In order to navigate and manage your bookmarks, a few commands are provided:
+
+   | Command                                    | Emacs | Vi  |
+   |--------------------------------------------+-------+-----|
+   | Open Bookmark                              | ~C-m o~ | ~m o~ |
+   | Bookmark Current Page                      | ~C-m m~ | ~m m~ |
+   | Delete Bookmark                            | ~C-m k~ | ~m k~ |
+   | Bookmark URL (input URL via minibuffer)    | ~C-m u~ | ~m u~ |
+   | Bookmark Anchor (input URL via link hints) | ~C-m g~ | ~m a~ |
 
 ** Clearing the Echo Area
 In the area at the bottom of the screen where the minibuffer resides,

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -193,9 +193,7 @@ If FILE is \"-\", read from the standard input."
 (define-key "C-x k" 'delete-buffer)
 (define-key "C-l" 'set-url-current-buffer)
 (define-key "M-l" 'set-url-new-buffer)
-(define-key "C-m k" 'bookmark-delete)
 (define-key "C-t" 'make-visible-new-buffer)
-(define-key "C-m u" 'bookmark-url)
 (define-key "C-x w" 'delete-active-buffer)
 ;; TODO: Rename to inspect-variable?  Wouldn't describe-variable be more familiar?
 (define-key "C-h v" 'variable-inspect)
@@ -215,10 +213,7 @@ If FILE is \"-\", read from the standard input."
   "d" 'delete-buffer
   "D" 'delete-active-buffer
   "B" 'make-visible-new-buffer
-  "o" 'set-url-current-buffer
   "O" 'set-url-new-buffer
-  "m u" 'bookmark-url
-  "m d" 'bookmark-delete
   "C-o" 'load-file
   "C-h v" 'variable-inspect
   "C-h c" 'command-inspect

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -74,8 +74,8 @@
       (when selected-link
         (%bookmark-url selected-link)))))
 
-(define-command set-url-from-bookmark ()
-  "Set the URL for the current buffer from a bookmark."
+(define-command bookmark-open-bookmark ()
+  "Open current highlighted bookmark in the current buffer."
   (with-result (url (read-from-minibuffer
                      (minibuffer *interface*)
                      :input-prompt "Open bookmark:"

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -3,87 +3,91 @@
 (in-package :next)
 
 (define-mode document-mode ()
-    "Base mode for interacting with documents."
-    ((active-history-node :accessor active-history-node :initarg :active-node
-                          :initform (make-instance 'node :data "about:blank"))
-     (link-hints :accessor link-hints)
-     (keymap-schemes
-      :initform
-      (let ((emacs-map (make-keymap))
-            (vi-map (make-keymap)))
-        (define-key :keymap emacs-map
-          "M-f" 'history-forwards-query
-          "M-b" 'history-backwards
-          "C-g" 'go-anchor
-          "M-g" 'go-anchor-new-buffer-focus
-          "C-u M-g" 'go-anchor-new-buffer
-          "C-x C-w" 'copy-anchor-url
-          "C-f" 'history-forwards
-          "C-b" 'history-backwards
-          "button9" 'history-forwards
-          "button8" 'history-backwards
-          "C-p" 'scroll-up
-          "C-n" 'scroll-down
-          "C-x C-=" 'zoom-in-page
-          "C-x C-HYPHEN" 'zoom-out-page
-          "C-x C-0" 'unzoom-page
-          "C-r" 'reload-current-buffer
-          "C-m o" 'set-url-from-bookmark
-          "C-m s" 'bookmark-current-page
-          "C-m g" 'bookmark-anchor
-          "C-s s" 'add-search-hints
-          "C-s n" 'next-search-hint
-          "C-s p" 'previous-search-hint
-          "C-s k" 'remove-search-hints
-          "C-." 'jump-to-heading
-          "M-s->" 'scroll-to-bottom
-          "M-s-<" 'scroll-to-top
-          "M->" 'scroll-to-bottom
-          "M-<" 'scroll-to-top
-          "C-v" 'scroll-page-down
-          "M-v" 'scroll-page-up
-          "C-w" 'copy-url
-          "M-w" 'copy-title
-          "SPACE" 'scroll-page-down
-          "s-SPACE" 'scroll-page-up)
-        (define-key :keymap vi-map
-          "H" 'history-backwards
-          "L" 'history-forwards
-          "f" 'go-anchor
-          "F" 'go-anchor-new-buffer-focus
-          "; f" 'go-anchor-new-buffer
-          "button9" 'history-forwards
-          "button8" 'history-backwards
-          "h" 'scroll-left
-          "j" 'scroll-down
-          "k" 'scroll-up
-          "l" 'scroll-right
-          "Left" 'scroll-left
-          "Down" 'scroll-down
-          "Up" 'scroll-up
-          "Right" 'scroll-right
-          "z i" 'zoom-in-page
-          "z o" 'zoom-out-page
-          "z z" 'unzoom-page
-          "r" 'reload-current-buffer
-          "m o" 'set-url-from-bookmark
-          "m m" 'bookmark-current-page
-          "m f" 'bookmark-anchor
-          "y u" 'copy-url
-          "y t" 'copy-title
-          "g h" 'jump-to-heading        ; TODO: VI binding for this?
-          "/" 'add-search-hints
-          "n" 'next-search-hint
-          "N" 'previous-search-hint
-          "?" 'remove-search-hints
-          "G" 'scroll-to-bottom
-          "g g" 'scroll-to-top
-          "C-f" 'scroll-page-down
-          "C-b" 'scroll-page-up
-          "SPACE" 'scroll-page-down
-          "s-SPACE" 'scroll-page-up)
-        (list :emacs emacs-map
-              :vi-normal vi-map))))
+  "Base mode for interacting with documents."
+  ((active-history-node :accessor active-history-node :initarg :active-node
+                        :initform (make-instance 'node :data "about:blank"))
+   (link-hints :accessor link-hints)
+   (keymap-schemes
+    :initform
+    (let ((emacs-map (make-keymap))
+          (vi-map (make-keymap)))
+      (define-key :keymap emacs-map
+        "M-f" 'history-forwards-query
+        "M-b" 'history-backwards
+        "C-g" 'go-anchor
+        "M-g" 'go-anchor-new-buffer-focus
+        "C-u M-g" 'go-anchor-new-buffer
+        "C-x C-w" 'copy-anchor-url
+        "C-f" 'history-forwards
+        "C-b" 'history-backwards
+        "button9" 'history-forwards
+        "button8" 'history-backwards
+        "C-p" 'scroll-up
+        "C-n" 'scroll-down
+        "C-x C-=" 'zoom-in-page
+        "C-x C-HYPHEN" 'zoom-out-page
+        "C-x C-0" 'unzoom-page
+        "C-r" 'reload-current-buffer
+        "C-s s" 'add-search-hints
+        "C-s n" 'next-search-hint
+        "C-s p" 'previous-search-hint
+        "C-s k" 'remove-search-hints
+        "C-." 'jump-to-heading
+        "M-s->" 'scroll-to-bottom
+        "M-s-<" 'scroll-to-top
+        "M->" 'scroll-to-bottom
+        "M-<" 'scroll-to-top
+        "C-v" 'scroll-page-down
+        "M-v" 'scroll-page-up
+        "C-w" 'copy-url
+        "M-w" 'copy-title
+        "SPACE" 'scroll-page-down
+        "s-SPACE" 'scroll-page-up
+        "C-m o" 'bookmark-open-bookmark
+        "C-m m" 'bookmark-current-page
+        "C-m a" 'bookmark-anchor
+        "C-m u" 'bookmark-url
+        "C-m k" 'bookmark-delete)
+      (define-key :keymap vi-map
+        "H" 'history-backwards
+        "L" 'history-forwards
+        "f" 'go-anchor
+        "F" 'go-anchor-new-buffer-focus
+        "; f" 'go-anchor-new-buffer
+        "button9" 'history-forwards
+        "button8" 'history-backwards
+        "h" 'scroll-left
+        "j" 'scroll-down
+        "k" 'scroll-up
+        "l" 'scroll-right
+        "Left" 'scroll-left
+        "Down" 'scroll-down
+        "Up" 'scroll-up
+        "Right" 'scroll-right
+        "z i" 'zoom-in-page
+        "z o" 'zoom-out-page
+        "z z" 'unzoom-page
+        "r" 'reload-current-buffer
+        "y u" 'copy-url
+        "y t" 'copy-title
+        "g h" 'jump-to-heading        ; TODO: VI binding for this?
+        "/" 'add-search-hints
+        "n" 'next-search-hint
+        "N" 'previous-search-hint
+        "?" 'remove-search-hints
+        "G" 'scroll-to-bottom
+        "g g" 'scroll-to-top
+        "C-f" 'scroll-page-down
+        "C-b" 'scroll-page-up
+        "SPACE" 'scroll-page-down
+        "s-SPACE" 'scroll-page-up
+        "m o" 'bookmark-open-bookmark
+        "m m" 'bookmark-current-page
+        "m k" 'bookmark-delete
+        "m u" 'bookmark-url
+        "m a" 'bookmark-anchor)
+      (list :emacs emacs-map
+            :vi-normal vi-map))))
   ;; Init.
   ;; TODO: Do we need to set the default URL?  Maybe not.
   ;; (set-url-buffer (default-new-buffer-url (buffer %mode))


### PR DESCRIPTION
Hi,

This a small commit, tested in emacs and vi bindings:

- Rename `set-url-from-bookmark` function to `bookmark-open-bookmark`
Cosmetic change, keeping all bookmarks functions starting with `bookmark-...`

- Move all bookmarks bindings to document-mode
There are bindings everywhere, maybe a dedicated `bindings.lisp` file would be interesting. Anyway, I just bundled all bookmarks bindings together.

- Bookmarks bindings following its name: bookmark-anchor (c-m a)
At first I tried to keep all bindings following its function name, but I noticed that some would be easier to type with nearest letters  instead. So I just changed two bindings while keeping delete and current intact.

- Update bookmark se change than importantction on manual.org
Vim bindings are not yet on Manual.org, so I add it and a table.

PS: If you all agree I might improve manual.org by adding tables, improving text and adding lacking bindings and documentation...

:D