### PR TITLE
Add cookies parameter to blocker mode resource-query-block.

### DIFF
--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -80,6 +80,7 @@ Auto-update file if older than UPDATE-INTERVAL seconds."
 
 (defmethod resource-query-block ((buffer buffer)
                                  &key url
+				   cookies
                                    event-type
                                    (is-new-window nil)
                                    (is-known-type t)
@@ -95,6 +96,7 @@ Fall back on `resource-query-default'."
         nil)
       (resource-query-default buffer
                               :url url
+			      :cookies cookies
                               :event-type event-type
                               :is-new-window is-new-window
                               :is-known-type is-known-type


### PR DESCRIPTION
Related to issue https://github.com/atlas-engineer/next/issues/32

This fixes the following error when blocker-mode is enabled:
   WARNING:
   Method handler (NEXT::CORE-OBJECT
                   NEXT::REQUEST-RESOURCE) signaled an error: invalid keyword
                                                              argument:
                                                              :COOKIES (valid
                                                              keys are
                                                              :MODIFIERS,
                                                              :MOUSE-BUTTON,
                                                              :IS-KNOWN-TYPE,
                                                              :IS-NEW-WINDOW,
                                                              :EVENT-TYPE,
                                                              :URL)..