### PR TITLE
Vindarel/improve fuzzy match

### DIFF
--- a/next.asd
+++ b/next.asd
@@ -11,6 +11,7 @@
                :cl-strings
                :str
                :cl-string-match
+               :mk-string-metrics
                :quri
                :sqlite
                :parenscript

--- a/tests/test-utility.lisp
+++ b/tests/test-utility.lisp
@@ -7,8 +7,6 @@
 
 (plan nil)
 
-(setf next::*interface* (make-instance 'next::remote-interface))
-
 (defparameter *candidates* '("link-hints" "active-history-node" "history-backwards"
                              "did-finish-navigation" "history-forwards"
                              "history-forwards-query" "copy-title" "did-commit-navigation"
@@ -61,4 +59,12 @@
   (is "delete-foo" (first (fuzzy-match "de"
                                        '("some-mode" "delete-foo")))
       "candidates beginning with the first word appear first")
-  )
+
+  (is "foo-bar" (first (fuzzy-match "foobar"
+                                    '("foo-dash-bar" "foo-bar")))
+      "search witout a space. All characters count (small list).")
+  (is "switch-buffer" (first (fuzzy-match "sbf"
+                                    *candidates*))
+      "search witout a space. All characters count, real list."))
+
+(finalize)

--- a/tests/test-utility.lisp
+++ b/tests/test-utility.lisp
@@ -1,0 +1,64 @@
+(defpackage :next.tests
+  (:use :common-lisp
+        :next
+        :prove))
+
+(in-package :next.tests)
+
+(plan nil)
+
+(setf next::*interface* (make-instance 'next::remote-interface))
+
+(defparameter *candidates* '("link-hints" "active-history-node" "history-backwards"
+                             "did-finish-navigation" "history-forwards"
+                             "history-forwards-query" "copy-title" "did-commit-navigation"
+                             "copy-url" "add-or-traverse-history" "set-url-new-buffer"
+                             "noscript-mode" "help" "jump-to-heading" "next-search-hint"
+                             "bookmark-current-page" "new-buffer" "command-inspect"
+                             "add-search-hints" "kill" "remove-search-hints" "load-file"
+                             "keymap" "next-version" "name" "scroll-left" "activate"
+                             "scroll-page-down" "scroll-right" "destructor"
+                             "scroll-to-bottom" "switch-buffer-next" "command-evaluate"
+                             "did-finish-navigation" "bookmark-anchor" "scroll-down"
+                             "scroll-up" "vi-button1" "reload-current-buffer"
+                             "copy-anchor-url" "bookmark-delete" "go-anchor-new-buffer"
+                             "zoom-out-page" "keymap-schemes" "buffer" "new-window"
+                             "execute-command" "make-visible-new-buffer" "download-url"
+                             "switch-buffer" "application-mode" "delete-buffer"
+                             "start-swank" "did-commit-navigation" "delete-window"
+                             "bookmark-url" "unzoom-page" "load-init-file"
+                             "download-anchor-url" "zoom-in-page" "document-mode"
+                             "scroll-to-top" "vi-insert-mode" "help-mode" "vi-normal-mode"
+                             "minibuffer-mode" "proxy-mode" "blocker-mode"
+                             "delete-current-buffer" "scroll-page-up"
+                             "set-url-from-bookmark" "switch-buffer-previous"
+                             "download-list" "download-mode" "set-url-current-buffer"
+                             "about" "variable-inspect" "go-anchor" "previous-search-hint"
+                             "go-anchor-new-buffer-focus")
+  "existing next commands.")
+
+(subtest "Fuzzy match"
+  (is "help" (first (fuzzy-match "hel"
+                                 '("help-mode" "help" "foo-help" "help-foo-bar"))))
+  (is "help" (first (fuzzy-match "hel"
+                                 *candidates*))
+      "match 'help' with real candidates list")
+  (is "switch-buffer" (first (fuzzy-match "swit buf"
+                                          '("about" "switch-buffer-next" "switch-buffer"
+                                            "delete-buffer")))
+      "match 'swit buf' (small list)")
+  (is "switch-buffer" (first (fuzzy-match "swit buf"
+                                          *candidates*))
+      "match 'swit buf' with real candidates list")
+  (is "switch-buffer" (first (fuzzy-match "buf swit"
+                                          '("about" "switch-buffer-next" "switch-buffer"
+                                            "delete-buffer")))
+      "reverse match 'buf swit' (small list)")
+  (is "switch-buffer" (first (fuzzy-match "buf swit"
+                                          *candidates*))
+      "reverse match 'buf swit' with real candidates list")
+
+  (is "delete-foo" (first (fuzzy-match "de"
+                                       '("some-mode" "delete-foo")))
+      "candidates beginning with the first word appear first")
+  )


### PR DESCRIPTION
Improved M-x fuzzy match:

- Major improvement: the order of input words is not important: `M-x "swit buf"` gives the same results as `"buf swit"`
- Candidates are sorted by "best matching" with the levenshtein distance
- Candidates that start with the first written word come first.

(edit) However: there's `mk-strings-metrics` to bundle for Guix. Maybe can we find a light replacement.

It looks ok, it doesn't break the previous behavior (`sbp` gives `switch-buffer-previous`).

See examples in the test file. Ok I put a little gif :)  (low quality sorry)

![vokoscreen-2019-07-29_23-33-23](https://user-images.githubusercontent.com/3721004/62084337-65b98000-b259-11e9-996a-99c6b07abb66.gif)


Possible improvements: better function names. Put this in a package of its own for further re-usability.