### PR TITLE
M-x open-file: open any file from the minibuffer with fuzzy completion

### DIFF
--- a/documents/CHANGELOG.org
+++ b/documents/CHANGELOG.org
@@ -70,7 +70,7 @@ Press =Enter= to  visit a file, =M-Left= or =C-l=  to go one directory
 up, =M-Right= or =C-j= to browse the directory at point.
 
 By default, it uses the =xdg-open=  command. The user can override the
-=next:*open-file-fn*= variable  with a new function,  which takes the
+=next:*open-file-function*= variable  with a new function,  which takes the
 filename  (or directory  name) as  parameter.  See the  manual for  an
 example.
 

--- a/documents/CHANGELOG.org
+++ b/documents/CHANGELOG.org
@@ -57,6 +57,27 @@ MAJOR.MINOR.PATCH, we increment the:
   imported, say, from Firefox, or exported to a SQLite database or a custom text
   format.
 
+** TASK 1.3.2 (Upcoming)
+*** New open-file command (C-x C-f)
+
+This new command allows to open a file from the filesystem.
+
+The user is prompted with the minibuffer, files are browsable with the fuzzy completion.
+
+The default directory is the one from the download manager.
+
+Press =Enter= to  visit a file, =M-Left= or =C-l=  to go one directory
+up, =M-Right= or =C-j= to browse the directory at point.
+
+By default, it uses the =xdg-open=  command. The user can override the
+=next:*open-file-fn*= variable  with a new function,  which takes the
+filename  (or directory  name) as  parameter.  See the  manual for  an
+example.
+
+The default keybinding is =C-x C-f=.
+
+__Note__: this feature is alpha and is meant to grow in Next 1.4 and beyond!
+
 ** DONE 1.3.1 (Upcoming)
 *** Print page title in buffer list
 And the title is matched when fuzzy-searching a buffer!

--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -472,10 +472,10 @@ The default keybindings for ~vi-normal-mode~ are:
 ** Decide how to open files
 
 The commands  =open-file= and  =download-open-file= call  the function
-=open-file-fn <filename>=. Its  default behaviour is to  open the file
+=open-file-function <filename>=. Its  default behaviour is to  open the file
 with the  system's default, using  =xdg-open=.  You can  override this
 behaviour   by    binding   another    function   to    the   variable
-=next:*open-file-fn*=.
+=next:*open-file-function*=.
 
 For example:
 
@@ -487,10 +487,10 @@ For example:
                     ((member extension '("flv" "mkv" "mp4") :test #'string=)
                      (uiop:run-program (list "mpv" filename)))
                     (t
-                     (next::open-file-fn-default filename))))
-    (error (c) (log:error "Error opening pdf ~a: ~a" filename c))))
+                     (next::open-file-function-default filename))))
+    (error (c) (log:error "Error opening ~a: ~a" filename c))))
 
-(setf next:*open-file-fn* #'my-open-videos)
+(setf next:*open-file-function* #'my-open-videos)
 #+end_src
 
 ** Loading Files

--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -16,6 +16,7 @@ end-user allowing for infinite customization.
   - [[#history][History]]
   - [[#bookmarks][Bookmarks]]
   - [[#download-manager][Download manager]]
+  - [[#opening-files][Opening files]]
   - [[#clearing-the-echo-area][Clearing the Echo Area]]
   - [[#exiting][Exiting]]
   - [[#proxy-and-tor-support][Proxy and Tor support]]
@@ -266,6 +267,19 @@ as usual, and also with =M-x download-list=.
 To open  a file, use  =M-x download-open-file=. See  the customization
 section to control how files are open.
 
+** Opening files
+
+With =M-x open-file= (bound to =C-x  C-f=), you are prompted a list of
+files, and you can select one with the usual fuzzy completion. You can
+go one directory  up with =M-Left= or =C-l=, and  enter the directory
+at point with =M-Right= or =C-j=.
+
+Next  will open  the  file  with the  system's  default program  using
+=xdg-open=.  See  the  command  help  for  further  details,  and  the
+customization section to override the default behavior.
+
+__Note__: this feature is alpha and is meant to grow in Next 1.4 and onwards.
+
 ** Clearing the Echo Area
 In the area at the bottom of the screen where the minibuffer resides,
 Next will occasionally display messages. These can be dismissed by
@@ -457,22 +471,26 @@ The default keybindings for ~vi-normal-mode~ are:
 
 ** Decide how to open files
 
-The command =M-x download-open-file=, which is  used to open a file we
-downloaded  in  the  current  session,  calls  in  turn  the  function
-=open-file <filename>=. Its default behaviour is to open the file with
-the  system's  default,  using   =xdg-open=.  You  can  override  this
-behaviour by re-defining this function.
+The commands  =open-file= and  =download-open-file= call  the function
+=open-file-fn <filename>=. Its  default behaviour is to  open the file
+with the  system's default, using  =xdg-open=.  You can  override this
+behaviour   by    binding   another    function   to    the   variable
+=next:*open-file-fn*=.
 
 For example:
 
 #+begin_src lisp
-(defun open-file (filename)
-  "Open PDFs with Emacs."
+(defun my-open-videos (filename)
+  "Open videos with `mpv'."
   (handler-case (let ((extension (pathname-type filename)))
-                  (str:string-case extension
-                                   ("pdf" (uiop:run-program (list "emacs" filename)))
-                                   (otherwise (next::open-file-default filename))))
-    (error (c) (format *error-output* "Error opening pdf ~a: ~a" filename c))))
+                  (cond
+                    ((member extension '("flv" "mkv" "mp4") :test #'string=)
+                     (uiop:run-program (list "mpv" filename)))
+                    (t
+                     (next::open-file-fn-default filename))))
+    (error (c) (log:error "Error opening pdf ~a: ~a" filename c))))
+
+(setf next:*open-file-fn* #'my-open-videos)
 #+end_src
 
 ** Loading Files

--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -481,14 +481,14 @@ For example:
 
 #+begin_src lisp
 (defun my-open-videos (filename)
-  "Open videos with `mpv'."
+  "Open videos with mpv."
   (handler-case (let ((extension (pathname-type filename)))
-                  (cond
-                    ((member extension '("flv" "mkv" "mp4") :test #'string=)
-                     (uiop:run-program (list "mpv" filename)))
-                    (t
+                  (match extension
+                    ((or "flv" "mkv" "mp4")
+                     (uiop:launch-program (list "mpv" filename)))
+                    (_
                      (next::open-file-function-default filename))))
-    (error (c) (log:error "Error opening ~a: ~a" filename c))))
+    (error (c) (log:error "Error opening pdf ~a: ~a" filename c))))
 
 (setf next:*open-file-function* #'my-open-videos)
 #+end_src

--- a/next.asd
+++ b/next.asd
@@ -63,6 +63,7 @@
                  (:file "proxy-mode")
                  (:file "noscript-mode")
                  (:file "download-mode")
+                 (:file "file-manager-mode")
                  ;; About
                  (:file "about")
                  ;; Port Compatibility Layers

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -82,23 +82,6 @@
     (lambda (input)
       (fuzzy-match input filenames))))
 
-(defun open-file-default (filename)
-  "Open this file with `xdg-open'."
-  (handler-case (uiop:run-program (list "xdg-open" filename))
-    ;; We can probably signal something and display a notification.
-    (error (c) (format *error-output* "Error opening ~a: ~a~&" filename c))))
-
-;; TODO: Remove `open-file` (it's just a one-liner) and instead store the
-;; "open-file-function" into a download-mode slot, which is then called from
-;; `download-open-file' with `(funcall (open-file-function download-mode)
-;; filename).
-(export 'open-file)  ;; the user is encouraged to override this in her init file.
-(defun open-file (filename)
-  "Open this file. `filename' is the full path of the file, as a string.
-By default, try to open it with the system's default external program, using `xdg-open'.
-The user can override this function to decide what to do with the file."
-  (open-file-default filename))
-
 (define-command download-open-file (root-mode &optional (interface *interface*))
   "Open a downloaded file.
 Ask the user to choose one of the downloaded files of the current session.
@@ -107,4 +90,4 @@ See also `open-file'."
                           (minibuffer *interface*)
                           :input-prompt "Open file:"
                           :completion-function (downloaded-files-completion-fn interface)))
-    (open-file filename)))
+    (open-file-fn filename)))

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -90,4 +90,4 @@ See also `open-file'."
                           (minibuffer *interface*)
                           :input-prompt "Open file:"
                           :completion-function (downloaded-files-completion-fn interface)))
-    (open-file-fn filename)))
+    (open-file-function filename)))

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -60,11 +60,26 @@
         (dirnames (uiop:subdirectories directory)))
     (fuzzy-match input (append filenames dirnames))))
 
-;TODO: define a new mode and specialize keybinings on it !
-
 (define-mode open-file-mode (minibuffer-mode)
-    "doc"
-    ())
+    "Mode to open any file from the filesystem with fuzzy completion
+on the minibuffer. Specialize keybindings on this mode. See the
+command `open-file'."
+    ((keymap-schemes
+      :initform
+      (let ((emacs-map (make-keymap))
+            (vi-map (make-keymap)))
+
+        (define-key :keymap emacs-map
+          "M-Left" 'display-parent-directory
+          "C-l" 'display-parent-directory
+          "C-j" 'enter-directory
+          "M-Right" 'enter-directory)
+
+        (define-key :keymap vi-map
+          "M-Left" 'display-parent-directory)
+
+        (list :emacs emacs-map
+              :vi-normal vi-map)))))
 
 (defclass open-file-instance ()
   ((default-modes :initform '(open-file-mode))
@@ -116,6 +131,7 @@ Note: this feature is alpha, get in touch for more !"
     (setf mode (make-instance  'open-file-mode))
     ;; populate needed slots...
     (setf (buffer mode) (minibuffer *interface*))
+    ;; Allow the current minibuffer to recognize our keybindings.
     (push mode (modes (minibuffer *interface*)))
     (with-result (filename (read-from-minibuffer
                             (minibuffer *interface*)
@@ -129,11 +145,6 @@ Note: this feature is alpha, get in touch for more !"
 
 
 (define-key  "C-x C-f" #'open-file)
-;; (define-key :mode 'vi-normal-mode  "e" #'open-file) ;TODO:
 
-(define-key :mode 'open-file-mode  "C-l" #'display-parent-directory)
-(define-key :mode 'open-file-mode  "M-Left" #'display-parent-directory)
-(define-key :mode 'open-file-mode  "M-Left" #'display-parent-directory)
-
-(define-key :mode 'open-file-mode  "C-j" #'enter-directory)
-(define-key :mode 'open-file-mode  "M-Right" #'enter-directory)
+;; This currently dosen't work, we must use the keymap at the mode definition:
+;; (define-key :mode 'open-file-mode  "M-Left" #'display-parent-directory)

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -35,7 +35,7 @@
 
 (defun open-file-function-default (filename)
   "Open this file with `xdg-open'."
-  (handler-case (uiop:run-program (list "xdg-open" (namestring filename)))
+  (handler-case (uiop:launch-program (list "xdg-open" (namestring filename)))
     ;; We can probably signal something and display a notification.
     (error (c) (log:error "Error opening ~a: ~a~&" filename c))))
 

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -1,0 +1,116 @@
+;;; file-manager-mode.lisp -- Manage files.
+;;;
+;;; Open any file from within Next, with the usual fuzzy completion.
+;;;
+;;; `M-x open-file (C-x C-f)'
+;;;
+;;; "file manager" is a big excessive for now. Currently, we can:
+;;; - browse files, with fuzzy-completion
+;;; - go one directory up (C-l)
+;;; - enter a directory (C-j)
+;;; - open files. By default, with xdg-open. See `open-file-fn'.
+;;;
+;;; ***********************************************************************
+;;; *Disclaimer*: this feature is meant to grow with Next 1.4 and onwards!
+;;; ***********************************************************************
+;;;
+;;; Much can be done:
+;;; - configuration options to choose what to open with
+;;; - more configuration in general
+;;; - sort by last access, etc
+;;; - multi-selection
+;;; - bookmarks
+;;; - open files in Next
+;;; - a UI to list files
+;;; - lazy loading for large directories
+;;; - many things...
+;;;
+
+(in-package :next)
+
+(defvar *current-directory* download-manager::*default-download-directory*
+  "Default directory to open files from. Defaults to the downloads directory.")
+
+(defun open-file-fn-default (filename)
+  "Open this file with `xdg-open'."
+  (handler-case (uiop:run-program (list "xdg-open" (namestring filename)))
+    ;; We can probably signal something and display a notification.
+    (error (c) (log:error "Error opening ~a: ~a~&" filename c))))
+
+;; TODO: Remove `open-file-fn` (it's just a one-liner) and instead store the
+;; "open-file-function" into a download-mode slot, which is then called from
+;; `download-open-file' with `(funcall (open-file-function download-mode)
+;; filename).
+(defun open-file-fn (filename)
+  "Open `filename'.
+`filename' is the full path of the file (or directory), as a string.
+By default, try to open it with the system's default external program, using `xdg-open'.
+The user can override this function to decide what to do with the file."
+  (open-file-fn-default filename))
+
+;; note: put under the function definition.
+(export '*open-file-fn*)   ;; the user is encouraged to override this in her init file.
+(defparameter *open-file-fn* #'open-file-fn
+  "Function triggered to open files.")
+
+(defun open-file-from-directory-completion-fn (input &optional (directory *current-directory*))
+  "Fuzzy-match files and directories from `*current-directory*'."
+  (let ((filenames (uiop:directory-files directory))
+        (dirnames (uiop:subdirectories directory)))
+    (fuzzy-match input (append filenames dirnames))))
+
+(define-command display-parent-directory (minibuffer-mode &optional (minibuffer (minibuffer *interface*)))
+  "Get the parent directory and update the minibuffer.
+
+Default keybindings: `M-Left' and `C-l'."
+  (setf *current-directory* (uiop:pathname-parent-directory-pathname *current-directory*))
+  (erase-input minibuffer)
+  (update-display minibuffer))
+
+(define-command enter-directory (minibuffer-mode &optional (minibuffer (minibuffer *interface*)))
+  "If the candidate at point is a directory, refresh the minibuffer candidates with its list of files.
+
+Default keybindings: `M-Right' and `C-j'. "
+  (let ((filename (get-candidate minibuffer)))
+    (when (and (uiop:directory-pathname-p filename)
+               (uiop:directory-exists-p filename))
+      (setf *current-directory* filename)
+      (erase-input minibuffer)
+      (update-display minibuffer))))
+
+(define-command open-file (root-mode &optional (interface *interface*))
+  "Open a file from the filesystem.
+
+The user is prompted with the minibuffer, files are browsable with the
+fuzzy completion.
+
+The default directory is the one computed by
+`download-manager:default-download-directory' (certainly `~/Downloads').
+
+Press `Enter' to visit a file, `M-Left' or `C-l' to go one directory
+up, `M-Right' or `C-j' to browse the directory at point.
+
+By default, it uses the `xdg-open' command. The user can override the
+`next:open-file-fn' function, which takes the filename (or directory
+name) as parameter.
+
+The default keybinding is `C-x C-f'.
+
+Note: this feature is alpha, get in touch for more !"
+  (let ((directory *current-directory*))
+    (with-result (filename (read-from-minibuffer
+                            (minibuffer interface)
+                            :input-prompt (file-namestring directory)
+                            :completion-function #'open-file-from-directory-completion-fn))
+
+      (open-file-fn (namestring filename)))))
+
+
+(define-key  "C-x C-f" #'open-file)
+;; (define-key :mode 'vi-normal-mode  "e" #'open-file) ;TODO:
+
+(define-key :mode 'minibuffer-mode  "C-l" #'display-parent-directory)
+(define-key :mode 'minibuffer-mode  "M-Left" #'display-parent-directory)
+
+(define-key :mode 'minibuffer-mode  "C-j" #'enter-directory)
+(define-key :mode 'minibuffer-mode  "M-Right" #'enter-directory)

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -4,11 +4,11 @@
 ;;;
 ;;; `M-x open-file (C-x C-f)'
 ;;;
-;;; "file manager" is a big excessive for now. Currently, we can:
+;;; "file manager" is a bit excessive for now. Currently, we can:
 ;;; - browse files, with fuzzy-completion
 ;;; - go one directory up (C-l)
 ;;; - enter a directory (C-j)
-;;; - open files. By default, with xdg-open. See `open-file-fn'.
+;;; - open files. By default, with xdg-open. See `open-file-function'.
 ;;;
 ;;; ***********************************************************************
 ;;; *Disclaimer*: this feature is meant to grow with Next 1.4 and onwards!
@@ -24,7 +24,6 @@
 ;;; - a UI to list files
 ;;; - lazy loading for large directories
 ;;; - many things...
-;;;
 
 (in-package :next)
 
@@ -34,23 +33,23 @@
 (defvar *current-directory* download-manager::*default-download-directory*
   "Default directory to open files from. Defaults to the downloads directory.")
 
-(defun open-file-fn-default (filename)
+(defun open-file-function-default (filename)
   "Open this file with `xdg-open'."
   (handler-case (uiop:run-program (list "xdg-open" (namestring filename)))
     ;; We can probably signal something and display a notification.
     (error (c) (log:error "Error opening ~a: ~a~&" filename c))))
 
-(defun open-file-fn (filename)
+(defun open-file-function (filename)
   "Open `filename'.
 `filename' is the full path of the file (or directory), as a string.
 By default, try to open it with the system's default external program, using `xdg-open'.
 The user can override this function to decide what to do with the file."
-  (open-file-fn-default filename))
+  (open-file-function-default filename))
 
 ;; note: put under the function definition.
-(export '*open-file-fn*)
+(export '*open-file-function*)
 ;; the user is encouraged to override this in her init file.
-(defparameter *open-file-fn* #'open-file-fn
+(defparameter *open-file-function* #'open-file-function
   "Function triggered to open files.")
 
 (define-mode open-file-mode (minibuffer-mode)
@@ -120,7 +119,7 @@ Press `Enter' to visit a file, `M-Left' or `C-l' to go one directory
 up, `M-Right' or `C-j' to browse the directory at point.
 
 By default, it uses the `xdg-open' command. The user can override the
-`next:open-file-fn' function, which takes the filename (or directory
+`next:open-file-function' function, which takes the filename (or directory
 name) as parameter.
 
 The default keybinding is `C-x C-f'.
@@ -138,7 +137,7 @@ Note: this feature is alpha, get in touch for more !"
                             :completion-function #'open-file-from-directory-completion-fn
                             :cleanup-function #'clean-up-open-file-mode))
 
-      (funcall *open-file-fn* (namestring filename)))))
+      (funcall *open-file-function* (namestring filename)))))
 
 
 (define-key  "C-x C-f" #'open-file)

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -102,6 +102,11 @@ Default keybindings: `M-Right' and `C-j'. "
       (erase-input minibuffer)
       (update-display minibuffer))))
 
+(defun clean-up-open-file-mode ()
+  "Remove open-file-mode from the minibuffer modes, so that we don't clutter the usual minibuffers with our keybindings."
+  (setf (modes (minibuffer *interface*))
+        (last (modes (minibuffer *interface*)))))
+
 (define-command open-file ()
   "Open a file from the filesystem.
 
@@ -132,11 +137,10 @@ Note: this feature is alpha, get in touch for more !"
     (with-result (filename (read-from-minibuffer
                             (minibuffer *interface*)
                             :input-prompt (file-namestring directory)
-                            :completion-function #'open-file-from-directory-completion-fn))
+                            :completion-function #'open-file-from-directory-completion-fn
+                            :cleanup-function #'clean-up-open-file-mode))
 
-      (funcall *open-file-fn* (namestring filename))
-      ;TODO: remove open-file-mode
-      )))
+      (funcall *open-file-fn* (namestring filename)))))
 
 
 (define-key  "C-x C-f" #'open-file)

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -186,6 +186,12 @@ This should not rely on the minibuffer's content.")
      *interface* (rpc-window-active *interface*)
      (ps:ps (ps:chain document (write (ps:lisp input)))))))
 
+(defmethod erase-input ((minibuffer minibuffer))
+  "Clean-up the minibuffer input."
+  (setf (input-buffer minibuffer) "")
+  (setf (input-buffer-cursor minibuffer) 0)
+  (set-input minibuffer ""))
+
 (defmethod erase-document ((minibuffer minibuffer))
   (rpc-minibuffer-evaluate-javascript
    *interface* (rpc-window-active *interface*)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -47,7 +47,7 @@ To arguments have a special meanings beside the slot value of the mode:
 If :ACTIVATE is omitted, the mode is toggled."
   `(progn
      (defclass ,name ,(unless (eq (first direct-superclasses) t)
-                        (cons 'root-mode direct-superclasses))
+                        (append direct-superclasses '(root-mode)))
        ,direct-slots
        (:documentation ,docstring))
      (defmethod initialize-instance :after ((%mode ,name) &key) ; TODO: Change %mode to ,name?


### PR DESCRIPTION
That's pretty basic but useful. 


TODOs:
- [X] open a file from the downloads directory
- [X] go one directory up
- [X] enter one directory
- [x] create a mode (don't clobber minibuffer keymap)
  - ~~move stuff to class slost~~: a PR is coming to put everything under a package namespace.
- [x] ensure we have good configuration options (only overriding a function for now, manual ok).

Much, much can and will be added. We'll have a great resource with Lem's directory mode (https://github.com/cxxxr/lem/blob/188a5881b9ee054ab26d057371ce8ce133b33136/lib/core/directory-mode.lisp).
