### PR TITLE
utility.lisp: escape characters before building fuzzy-matching regex

### DIFF
--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -76,7 +76,7 @@ Otherwise, build a search query with the default search engine."
     (loop for char across input do
          (princ #\. stream)
          (princ #\* stream)
-         (princ char stream))
+         (princ (ppcre:quote-meta-chars (string char)) stream))
     ;; match any chars after final char in cleaned-input
     (princ #\. stream)
     (princ #\* stream)))

--- a/tests/test-utility.lisp
+++ b/tests/test-utility.lisp
@@ -70,5 +70,9 @@
                                     '("foo-dash-bar" "FOO-BAR")))
       "input is uppercase (small list).")
   )
+  (is "http://[1:0:0:2::3:0.]/" (first (fuzzy-match "[" '("test1"
+                                                          "http://[1:0:0:2::3:0.]/"
+                                                          "test2")))
+      "match regex meta-characters")
 
 (finalize)


### PR DESCRIPTION
Closes https://github.com/atlas-engineer/next/issues/313 (inability to
type left bracket for the switch-buffer command).

This is my first time writing common lisp, so I have no idea what I'm doing. I wrote a test to make sure that the bug I've fixed doesn't reappear but couldn't find a way to run the testsuite (`make test` didn't fail when I ran it without the `ppcre:quote-meta-chars` line so I assume it does something else than running the testsuite). Help with that would be great :)