### PR TITLE
Use OBJECT-STRING for current minibuffer candidate

### DIFF
--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -517,11 +517,11 @@ interpreted by `format'. "
   (insert (trivial-clipboard:text) minibuffer))
 
 (defmethod get-candidate ((minibuffer minibuffer))
-  "Return the current candidate in the minibuffer."
+  "Return the string for the current candidate in the minibuffer."
   (with-slots (completions completion-cursor)
       minibuffer
     (and completions
-         (format nil "~a" (nth completion-cursor completions)))))
+         (object-string (nth completion-cursor completions)))))
 
 (define-command copy-candidate (minibuffer-mode &optional (minibuffer (minibuffer *interface*)))
   "Paste clipboard text to input."


### PR DESCRIPTION
Using the call to FORMAT, the completion returned would be some sort
of unprintable-object representation (e.g. #<BUFFER {223f7}>) which
would not be accepted by the calling code. This change makes it return
the string associated with the object instead, as the caller expects.