### PR TITLE
Overhaul use of command class.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -2,6 +2,7 @@
 
 (in-package :next)
 
+;; TODO: Use standard `print-object' instead?
 (defmethod object-string ((buffer buffer))
   (name buffer))
 

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -68,10 +68,10 @@ deprecated and by what in the docstring."
     symbols))
 
 (defun package-variables ()
-  (remove-if-not #'boundp (package-defined-symbols)))
+  (remove-if (complement #'boundp) (package-defined-symbols)))
 
 (defun package-functions ()             ; TODO: Unused.  Remove?
-  (remove-if-not #'fboundp (package-defined-symbols)))
+  (remove-if (complement #'fboundp) (package-defined-symbols)))
 
 (defun package-methods ()               ; TODO: Unused.  Remove?
   (loop for sym in (package-defined-symbols)
@@ -84,13 +84,12 @@ Commands are instance of the `command' class.  When MODES are provided (as mode
 symbols), list only the commands that apply to this mode.  Otherwise list all
 commands."
   (if modes
-      (delete-duplicates (loop for command in %%command-list
-                               when (some
-                                     (lambda (m)
-                                       (closer-mop:subclassp (find-class (mode command))
-                                                             (find-class m)))
-                                     modes)
-                                 collect command))
+      (remove-if (lambda (c)
+                       (notany (lambda (m)
+                                 (closer-mop:subclassp (find-class (mode c))
+                                                       (find-class m)))
+                               modes))
+                     %%command-list)
       %%command-list))
 
 (defmethod object-string ((command command))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -30,7 +30,10 @@ ARGLIST must be a list of optional arguments."
                   (rest body)
                   body)))
     `(progn
-       (push (make-instance 'command :sym ',name :mode ',mode) %%command-list)
+       (unless (find-if (lambda (c) (and (eq (sym c) ',name)
+                                         (eq (mode c) ',mode)))
+                        %%command-list)
+         (push (make-instance 'command :sym ',name :mode ',mode) %%command-list))
        (defmethod ,name ,(cons `(,mode ,mode) arglist)
          ,documentation
          ,@body))))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -94,7 +94,15 @@ commands."
   ;; Use `last-active-window' for speed, or else the minibuffer will stutter
   ;; because of the RPC calls.
   (let* ((scheme (current-keymap-scheme (active-buffer (last-active-window *interface*))))
-         (bindings (getf (bindings command) scheme)))
+         (mode (find-mode (active-buffer (last-active-window *interface*))
+                          (mode command)))
+         (bindings '()))
+    (when mode
+      (let ((table (table (getf (keymap-schemes mode) scheme))))
+        (maphash (lambda (binding c)
+                   (when (eq c (sym command))
+                     (push (stringify binding) bindings)))
+                 table)))
     (if bindings
         (format nil "~a (~{~a~^, ~})" (sym command) bindings)
         (format nil "~a" (sym command)))))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -3,12 +3,6 @@
 
 (in-package :next)
 
-(defclass command ()
-  ((sym :accessor sym :initarg :sym)))
-
-(defvar *last-used-commands* nil
-  "A list of last used commands by the user. Most recent first.")
-
 (define-condition documentation-style-warning (style-warning)
   ((name :initarg :name :reader name)
    (subject-type :initarg :subject-type :reader subject-type))
@@ -36,7 +30,7 @@ ARGLIST must be a list of optional arguments."
                   (rest body)
                   body)))
     `(progn
-       (push ',name %%command-list)
+       (push (make-instance 'command :sym ',name :mode ',mode) %%command-list)
        (defmethod ,name ,(cons `(,mode ,mode) arglist)
          ,documentation
          ,@body))))
@@ -73,95 +67,44 @@ deprecated and by what in the docstring."
 (defun package-variables ()
   (remove-if-not #'boundp (package-defined-symbols)))
 
-(defun package-functions ()
+(defun package-functions ()             ; TODO: Unused.  Remove?
   (remove-if-not #'fboundp (package-defined-symbols)))
 
-(defun package-methods ()
+(defun package-methods ()               ; TODO: Unused.  Remove?
   (loop for sym in (package-defined-symbols)
         append (ignore-errors
                 (closer-mop:generic-function-methods (symbol-function sym)))))
 
-(defun list-commands (&optional mode)
+(defun list-commands (&rest modes)
   "List commands.
-A command is a mode method that is in the %%command-list.
-When MODE is a mode symbol, list only the commands that apply in this mode.
-Otherwise list all commands."
-  (loop for m in (package-methods)
-        for first-specializer = (first (closer-mop:method-specializers m))
-        when (and (member (command-symbol m)
-                          %%command-list)
-                  (closer-mop:subclassp first-specializer (find-class 'root-mode))
-                  (or (not mode)
-                      (closer-mop:subclassp (find-class mode) first-specializer)))
-          collect m))
-
-(defun command-symbol (command)
-  "Return the symbol of a command."
-  (closer-mop:generic-function-name
-   (closer-mop:method-generic-function command)))
-
-(defvar %%command-key-bindings (make-hash-table :test #'equal)
-  "Internal mapping of (key-binding command).
-This is used to memoize the results of `command-key-binding'.")
-
-;; TODO: Define memoized function to get rid of %%command-key-bindings.
-;; We need a way to force-reinitialize the memoization when bindings are updated.
-;; See http://quickdocs.org/fare-memoization/.
-(defun command-key-binding (command-symbol)
-  "Return the stringified key bound to COMMAND-symbol."
-  (multiple-value-bind (value present-p)
-      (gethash command-symbol %%command-key-bindings)
-    (if present-p
-        value
-        (let (key)
-          (find-if (lambda (mode)
-                     (let ((keymap (getf
-                                    (keymap-schemes mode)
-                                    (current-keymap-scheme (buffer mode)))))
-                       (setf key (first (find-if (lambda (key-command-pairs)
-                                                   (eq (rest key-command-pairs) command-symbol))
-                                                 (alexandria:hash-table-alist (table keymap)))))))
-                   (modes (active-buffer *interface*)))
-          (let ((stringified-key (if key (stringify key) nil)))
-            (setf (gethash command-symbol %%command-key-bindings) stringified-key)
-            stringified-key)))))
-
-(defmethod current-keymap-scheme ((buffer buffer))
-  "Return BUFFER's current-keymap-scheme."
-  (slot-value buffer 'current-keymap-scheme))
-
-(defmethod (setf current-keymap-scheme) (value (buffer buffer))
-  "Set the current-keymap-scheme of BUFFER to VALUE.
-This also resets `%%command-key-bindings' so that bindings are properly updated
-when displayed in the minibuffer."
-  (setf (slot-value buffer 'current-keymap-scheme) value)
-  (clrhash %%command-key-bindings))
+Commands are instance of the `command' class.  When MODES are provided (as mode
+symbols), list only the commands that apply to this mode.  Otherwise list all
+commands."
+  (if modes
+      (delete-duplicates (loop for command in %%command-list
+                               when (some
+                                     (lambda (m)
+                                       (closer-mop:subclassp (find-class (mode command))
+                                                             (find-class m)))
+                                     modes)
+                                 collect command))
+      %%command-list))
 
 (defmethod object-string ((command command))
-  (let ((binding (command-key-binding (sym command))))
-    (if binding
-        (format nil "~a (~a)" (sym command) binding)
+  ;; Use `last-active-window' for speed, or else the minibuffer will stutter
+  ;; because of the RPC calls.
+  (let* ((scheme (current-keymap-scheme (active-buffer (last-active-window *interface*))))
+         (bindings (getf (bindings command) scheme)))
+    (if bindings
+        (format nil "~a (~{~a~^, ~})" (sym command) bindings)
         (format nil "~a" (sym command)))))
-
-(defun %all-available-commands (interface)
-  "List the commands of all modes of this interface."
-  (mapcar #'command-symbol
-                       (delete-duplicates
-                        (loop for mode in (modes (active-buffer interface))
-                              append (list-commands (class-name (class-of mode)))))))
-
-;; TODO: Implement a more general "most-recent-access" sorting by using a sort
-;; function in fuzzy-match and by adding a "access-time" slot to commands.
-(defun all-available-commands (interface)
-  "List the Next commands for that interface. Re-order them a bit more user-friendly than a mere listing.
-Currently, we list the last used commands first."
-  (let ((commands (%all-available-commands interface)))
-    (mapcar (lambda (c) (make-instance 'command :sym c))
-            (remove-duplicates (append *last-used-commands* commands) :from-end t))))
 
 (defun command-complete (input)
   (fuzzy-match input
-               (all-available-commands *interface*)))
+               (sort (apply #'list-commands (mapcar (alexandria:compose #'class-name #'class-of)
+                                                    (modes (active-buffer *interface*))))
+                     (lambda (c1 c2)
+                       (> (access-time c1) (access-time c2))))))
 
 (define-command execute-command ()
   "Execute a command by name."
@@ -169,9 +112,5 @@ Currently, we list the last used commands first."
                          (minibuffer *interface*)
                          :input-prompt "Execute command:"
                          :completion-function 'command-complete))
-    (let ((mode (find-if (lambda (mode)
-                           (member (sym command) (mapcar #'command-symbol
-                                                         (list-commands (class-name (class-of mode))))))
-                         (modes (active-buffer *interface*)))))
-      (push (sym command) *last-used-commands*)
-      (funcall (sym command) mode))))
+    (setf (access-time command) (get-internal-real-time))
+    (funcall (sym command) (find-mode (active-buffer *interface*) (mode command)))))

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -11,7 +11,7 @@
       :initform
       (let ((emacs-map (make-keymap))
             (vi-map (make-keymap)))
-        (define-key :keymap emacs-map
+        (define-key :keymap emacs-map :scheme :emacs
           "M-f" 'history-forwards-query
           "M-b" 'history-backwards
           "C-g" 'follow-hint
@@ -24,7 +24,7 @@
           "button8" 'history-backwards
           "C-p" 'scroll-up
           "C-n" 'scroll-down
-          "C-x C-=" 'zoom-in-page ;
+          "C-x C-=" 'zoom-in-page
           "C-x C-+" 'zoom-in-page
           "C-x +" 'zoom-in-page
           "C-x C-HYPHEN" 'zoom-out-page
@@ -53,7 +53,7 @@
           "s-SPACE" 'scroll-page-up
           "Page_Up" 'scroll-page-up
           "Page_Down" 'scroll-page-down)
-        (define-key :keymap vi-map
+        (define-key :keymap vi-map :scheme :vi-normal
           "H" 'history-backwards
           "L" 'history-forwards
           "f" 'follow-hint

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -11,7 +11,7 @@
       :initform
       (let ((emacs-map (make-keymap))
             (vi-map (make-keymap)))
-        (define-key :keymap emacs-map :scheme :emacs
+        (define-key :keymap emacs-map
           "M-f" 'history-forwards-query
           "M-b" 'history-backwards
           "C-g" 'follow-hint
@@ -53,7 +53,7 @@
           "s-SPACE" 'scroll-page-up
           "Page_Up" 'scroll-page-up
           "Page_Down" 'scroll-page-down)
-        (define-key :keymap vi-map :scheme :vi-normal
+        (define-key :keymap vi-map
           "H" 'history-backwards
           "L" 'history-forwards
           "f" 'follow-hint

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -8,10 +8,10 @@
       :initform
       (let ((emacs-map (make-keymap))
             (vi-map (make-keymap)))
-        (define-key :keymap emacs-map :scheme :emacs
+        (define-key :keymap emacs-map
           "C-p" 'scroll-up
           "C-n" 'scroll-down)
-        (define-key :keymap vi-map :scheme :vi-normal
+        (define-key :keymap vi-map
           "k" 'scroll-up
           "j" 'scroll-down)
         (list :emacs emacs-map

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -8,10 +8,10 @@
       :initform
       (let ((emacs-map (make-keymap))
             (vi-map (make-keymap)))
-        (define-key :keymap emacs-map
+        (define-key :keymap emacs-map :scheme :emacs
           "C-p" 'scroll-up
           "C-n" 'scroll-down)
-        (define-key :keymap vi-map
+        (define-key :keymap vi-map :scheme :vi-normal
           "k" 'scroll-up
           "j" 'scroll-down)
         (list :emacs emacs-map
@@ -25,7 +25,7 @@
   (fuzzy-match input (package-variables)))
 
 (defun function-complete (input)
-  (fuzzy-match input (mapcar #'command-symbol (list-commands))))
+  (fuzzy-match input (mapcar #'sym (list-commands))))
 
 ;; TODO: This is barely useful as is since we don't have many globals.  We need to
 ;; augment the latter function so that we can inspect classes like remote-interface.

--- a/source/keymap.lisp
+++ b/source/keymap.lisp
@@ -183,22 +183,26 @@ registered into the mode class and all future mode instances will use the
 binding.
 If MODE and KEYMAP are nil, the binding is registered into root-mode.
 
-If SCHEME is unspecified, it defaults to :EMACS.  SCHEME is only useful together
-with MODE, it does not have any effect on KEYMAP.
+If SCHEME is unspecified, it defaults to :EMACS.
+
+SCHEME is also useful together with KEYMAP, where it serves as an indicator to
+display the binding for the right SCHEME in `execute-command'.
 
 Examples:
 
   (define-key \"C-x C-c\" 'quit)
-  (define-key \"C-n\" 'scroll-down
+  (define-key \"C-n\" 'history-forwards
               :mode 'document-mode)
   ;; Only affect the first mode of the current buffer:
   (define-key \"C-c C-c\" 'reload
-              :keymap (keymap (mode (active-buffer *interface*))))"
+              :keymap (getf (keymap-schemes (first (modes (active-buffer *interface*)))) :emacs))"
   (dolist (key (remove-if-not #'keywordp key-command-pairs))
     (remf key-command-pairs key))
   (when (and (null mode) (not (keymapp keymap)))
     (setf mode 'root-mode))
   (loop for (key-sequence-string command . rest) on key-command-pairs by #'cddr
+        for command-obj = (find-if (lambda (c) (eq (sym c) command))
+                                   %%command-list)
         do (when mode
              (setf (get-default mode 'keymap-schemes)
                    (let* ((map-scheme (closer-mop:slot-definition-initform
@@ -217,12 +221,13 @@ Examples:
                                    (make-keymap))))
                      (set-key map key-sequence-string command)
                      (setf (getf map-scheme scheme) map)
+                     (when command-obj
+                       (push key-sequence-string (getf (bindings command-obj) scheme)))
                      map-scheme)))
            (when (keymapp keymap)
-             (set-key keymap key-sequence-string command)))
-  ;; Reset map so that bindings are properly updated when displayed in the
-  ;; minibuffer.
-  (clrhash %%command-key-bindings))
+             (when command-obj
+               (push key-sequence-string (getf (bindings command-obj) scheme)))
+             (set-key keymap key-sequence-string command))))
 
 (defun key (key-sequence-string)
   "Turn KEY-SEQUENCE-STRING into a sequence of serialized key-chords.

--- a/source/keymap.lisp
+++ b/source/keymap.lisp
@@ -183,10 +183,9 @@ registered into the mode class and all future mode instances will use the
 binding.
 If MODE and KEYMAP are nil, the binding is registered into root-mode.
 
-If SCHEME is unspecified, it defaults to :EMACS.
-
-SCHEME is also useful together with KEYMAP, where it serves as an indicator to
-display the binding for the right SCHEME in `execute-command'.
+If SCHEME is unspecified, it defaults to :EMACS.  If SCHEME is unspecified, it
+defaults to :EMACS.  SCHEME is only useful together with MODE, it does not have
+any effect on KEYMAP.
 
 Examples:
 
@@ -201,8 +200,6 @@ Examples:
   (when (and (null mode) (not (keymapp keymap)))
     (setf mode 'root-mode))
   (loop for (key-sequence-string command . rest) on key-command-pairs by #'cddr
-        for command-obj = (find-if (lambda (c) (eq (sym c) command))
-                                   %%command-list)
         do (when mode
              (setf (get-default mode 'keymap-schemes)
                    (let* ((map-scheme (closer-mop:slot-definition-initform
@@ -221,12 +218,8 @@ Examples:
                                    (make-keymap))))
                      (set-key map key-sequence-string command)
                      (setf (getf map-scheme scheme) map)
-                     (when command-obj
-                       (push key-sequence-string (getf (bindings command-obj) scheme)))
                      map-scheme)))
            (when (keymapp keymap)
-             (when command-obj
-               (push key-sequence-string (getf (bindings command-obj) scheme)))
              (set-key keymap key-sequence-string command))))
 
 (defun key (key-sequence-string)

--- a/source/keymap.lisp
+++ b/source/keymap.lisp
@@ -195,7 +195,7 @@ Examples:
   ;; Only affect the first mode of the current buffer:
   (define-key \"C-c C-c\" 'reload
               :keymap (getf (keymap-schemes (first (modes (active-buffer *interface*)))) :emacs))"
-  (dolist (key (remove-if-not #'keywordp key-command-pairs))
+  (dolist (key (remove-if (complement #'keywordp) key-command-pairs))
     (remf key-command-pairs key))
   (when (and (null mode) (not (keymapp keymap)))
     (setf mode 'root-mode))

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -56,7 +56,10 @@ If :ACTIVATE is omitted, the mode is toggled."
      ;; call the destructor when toggling off.
      ;; TODO: Can we delete the last mode?  What does it mean to have no mode?
      ;; Should probably always have root-mode.
-     (push (make-instance 'command :sym ',name :mode ',name) %%command-list)
+     (unless (find-if (lambda (c) (and (eq (sym c) ',name)
+                                       (eq (mode c) 'root-mode)))
+                      %%command-list)
+       (push (make-instance 'command :sym ',name :mode 'root-mode) %%command-list))
      ,(unless (eq name 'root-mode)
         ;; REVIEW: Here we define the command manually instead of using
         ;; define-command, because this last macro depends on modes and thus

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -20,17 +20,11 @@
 ;;
 ;; - Customize minibuffer display value with `object-string'.
 ;;
-;; - Easy access to bindings: this is important for performance.  We used to
-;;   keep a separate hash table to memoize bindings, but it was too slow, even
-;;   on a hot cache.
-;;
 ;; - Access-time: This is useful to sort command by the time they were last
 ;;   called.  The only way to do this is to persist the command instances.
 (defclass command ()
   ((sym :accessor sym :initarg :sym)
    (mode :accessor mode :initarg :mode)
-   (bindings :accessor bindings :initform nil
-             :documentation "List of bindings, as a plist (:SCHEME (\"BINDINGS\"...)).")
    (access-time :accessor access-time :initform 0
                 :documentation "Last time this command was called from minibuffer.
 This can be used to order the commands.")))

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -24,7 +24,7 @@
 ;;   called.  The only way to do this is to persist the command instances.
 (defclass command ()
   ((sym :accessor sym :initarg :sym)
-   (mode :accessor mode :initarg :mode)
+   (mode :accessor mode :initarg :mode) ; TODO: Isn't it better to derive mode dynamically with closer-mop?
    (access-time :accessor access-time :initform 0
                 :documentation "Last time this command was called from minibuffer.
 This can be used to order the commands.")))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -40,6 +40,7 @@ keyword is not recognized.")))
                   :documentation "The list of symbols of class to
 instantiate on buffer creation, unless specified.")
    (current-keymap-scheme ; TODO: Name keymap-scheme instead?
+                          :accessor current-keymap-scheme
                           :initarg :current-keymap-scheme
                           :initform :emacs
                           :documentation "The keymap scheme that will be used

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -10,7 +10,7 @@
         (define-key
           "i" 'vi-insert-mode
           "button1" 'vi-button1
-          :keymap map)
+          :keymap map :scheme :vi-normal)
         (list :vi-normal map)))
      (destructor
       :initform

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -10,7 +10,7 @@
         (define-key
           "i" 'vi-insert-mode
           "button1" 'vi-button1
-          :keymap map :scheme :vi-normal)
+          :keymap map)
         (list :vi-normal map)))
      (destructor
       :initform


### PR DESCRIPTION
The command class has additional slots:
- `bindings' that replaces the `%%command-key-bindings' hash table (easier and
  faster).
- `mode' for convenience.
- `access-time' so we can sort by commands by recency of the call in the minibuffer.

The `object-string' method now displays all bindings of a command instead of
just the latest.

`execute-command' used to be broken in how it found the mode associated to a
command.  This is now fixed.

Many redundant and obsolete functions have been removed (command-symbol,
all-available-commands, etc.)

Know issue:
When calling `define-key` over a keymap, the `:scheme` argument is used to
register the binding in the command object.  This is not very dynamic: if we
manually add a keymap instance to a mode, the command `bindings' slot won't be updated.