### PR TITLE
Add Next channel instructions to build-scripts/guix.scm

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -1,7 +1,12 @@
 ;;; Commentary:
 ;;
-;; GNU Guix development package.  To build and install, clone this
-;; repository, cd into it and run:
+;; GNU Guix development package.  To build and install, first add
+;; the Next Guix Channel to your Guix configuration as described
+;; here:
+;;
+;; https://gitlab.com/atlas-engineer/next-guix-channel
+;; 
+;; Then, clone this repository, cd into it and run:
 ;;
 ;;   guix package -f guix.scm
 ;;


### PR DESCRIPTION
This change adds an extra bit of text to the header of `build-scripts/guix.scm` to instruct the user to add the Next Guix Channel to their Guix configuration before attempting to build the development package.  It seems that due to recent changes, this has become necessary.

Let me know if I can improve this in any way.  Thanks!

Fixes #333.