### PR TITLE
Print title in buffer list.

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -4,7 +4,7 @@
 
 ;; TODO: Use standard `print-object' instead?
 (defmethod object-string ((buffer buffer))
-  (name buffer))
+  (format nil "~a  ~a" (name buffer) (title buffer)))
 
 (defun make-buffer (&key (name "default")
                          default-modes)

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -33,6 +33,7 @@ keyword is not recognized.")))
 (defclass buffer ()
   ((id :accessor id :initarg :id)
    (name :accessor name :initarg :name)
+   (title :accessor title :initarg :title)
    (modes :accessor modes :initarg :modes :initform '()
           :documentation "The list of mode instances.")
    (default-modes :accessor default-modes :initarg :default-modes
@@ -129,6 +130,8 @@ See `rpc-buffer-make'."
 
 (defmethod did-commit-navigation ((buffer buffer) url)
   (setf (name buffer) url)
+  (with-result (title (buffer-get-title))
+    (setf (title buffer) title))
   (dolist (mode (modes buffer))
     (did-commit-navigation mode url)))
 


### PR DESCRIPTION
A rather trivial patch, but it shows one current annoyange with the asynchronous callbacks: it makes simple tasks like fetching the title non-trivial.
In particular, the return value of anything in `with-result` is a callback number and not the result of the body, which can be jarring to newcomers.

I propose to implement synchronous versions of `rpc-buffer-evaluate-javascript` and `rpc-minibuffer-evaluate-javascript`.
One approach would be to have the caller wait on a lock indexed by the callback-id and then have `buffer-javascript-call-back` unlock that lock and return the right value.

Thoughts?