### PR TITLE
Add native GitHub "Sponsor" button linking to Patreon and Indiegogo accounts

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: next_browser
+custom: https://www.indiegogo.com/projects/next-browser-v1-4-0#/


### PR DESCRIPTION
Simply merge this pull request and activate the "Sponsorships" option in next's project settings to get a cute little "Sponsor" button linking to your [Patreon](https://www.patreon.com/next_browser) and [Indiegogo](https://www.indiegogo.com/projects/next-browser-v1-4-0#/) accounts!

Here's a [preview](https://github.com/Hexstream/next) of the end result.

Here's the [official documentation](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for this nice feature.

(Note that you do not need to be sponsored by GitHub to use this feature.)

Further notes:

1. In your case, I guess this is slightly redundant given that you already prominently link to the Patreon and Indiegogo accounts in the README and on the site, but I guess it can't hurt, still. And I think it's important to promote this native GitHub funding integration feature to help normalize sustainable funding of open-source projects.

2. In the FUNDING.yml file, I have put the Patreon first and the Indiegogo second (even though you tend to order them the other way around) because Patreon is long-term while the Indiegogo campaign is limited-time. I'm not even sure if GitHub would put a "custom link" (Indiegogo) before a "native link" (Patreon), I haven't tested this. I could order them the other way around if you wish...