### PR TITLE
WIP: Persistence (session, history, bookmarks)

### DIFF
--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -34,6 +34,7 @@ end-user allowing for infinite customization.
   - [[#styles][Styles]]
   - [[#proxy][Proxy]]
   - [[#hooks][Hooks]]
+  - [[#startup-behaviour][Startup behaviour]]
 
 * Basics
 ** Navigation
@@ -655,3 +656,18 @@ can set a hook like the following in you =~/.config/next/init.lisp=:
 
 Some hooks like the above example expect a return value, so it's important to
 make sure we return ~url~ here.
+
+** Startup behaviour
+
+Once the platform port has been started, the default action of Next is to run
+
+#+begin_src lisp
+(funcall (startup-function *interface*) (or urls *free-args*))
+#+end_src
+
+~startup-function~ defaults to ~default-startup~ and takes URLs that are passed
+to Next as command line arguments.
+
+You can assign you own function to ~startup-function~ to change the behaviour of
+Next on startup, such as which URL it should display, if it should restore the
+previous session or not, etc.

--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -96,7 +96,7 @@ For instance, to search "parrot" on Wikipedia:
 
 From a Lisp REPL, you can query the list of search engines with
 #+begin_src lisp
-(get-default 'window 'search-engines)
+(get-default 'remote-interface 'search-engines)
 #+end_src
 
 It will return something like
@@ -111,7 +111,7 @@ The =~a= in the search engine URI is a place holder for the search pattern.
 To set the list of search engines, do:
 
 #+begin_src lisp
-(setf (get-default 'window 'search-engines)
+(setf (get-default 'remote-interface 'search-engines)
       '(("default" . "https://duckduckgo.com/?q=~a")
         ("yt" . "https://www.youtube.com/results?search_query=~a")
         ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a")))
@@ -120,7 +120,7 @@ To set the list of search engines, do:
 and to append a search engine do the list, you can do
 
 #+begin_src lisp
-(nconc (get-default 'window 'search-engines))
+(nconc (get-default 'remote-interface 'search-engines))
        '(("q" . "http://quickdocs.org/search?q=~a")
          ("yt" . "https://www.youtube.com/results?search_query=~a")))
 #+end_src

--- a/next.asd
+++ b/next.asd
@@ -40,6 +40,7 @@
                 :components
                 (;; Core Functionality
                  (:file "package")
+                 (:file "serialization")
                  (:file "macro")
                  (:file "global")
                  (:file "port")

--- a/next.asd
+++ b/next.asd
@@ -16,6 +16,7 @@
                :cl-markup
                :cl-ppcre
                :cl-ppcre-unicode
+               :cl-prevalence
                :closer-mop
                :dbus
                :dexador

--- a/next.asd
+++ b/next.asd
@@ -70,12 +70,12 @@
                  (:file "noscript-mode")
                  (:file "file-manager-mode")
                  (:file "download-mode")
-                 ;; About
-                 (:file "about")
                  ;; Port Compatibility Layers
                  (:file "ports/pyqt-webengine" :if-feature :darwin)
                  (:file "ports/gtk-webkit" :if-feature (:and :unix (:not :darwin)))
-                 ;; Base
+                 ;; Depends on everything else:
+                 (:file "about")
+                 (:file "session")
                  (:file "base"))))
   :build-operation "program-op"
   :build-pathname "next"

--- a/source/about.lisp
+++ b/source/about.lisp
@@ -4,8 +4,8 @@
   "Show the list of contributors."
   (let* ((buffer (make-buffer
                   :name "*About*"
-                  :default-modes (cons 'help-mode
-                                       (get-default 'buffer 'default-modes))))
+                  :modes (cons 'help-mode
+                               (get-default 'buffer 'default-modes))))
          (contents (cl-markup:markup
                     (:h1 "Crowdfunding backers")
                     (:p "Thank you to all who have supported and made Next possible!")

--- a/source/application-mode.lisp
+++ b/source/application-mode.lisp
@@ -3,6 +3,9 @@
 
 (in-package :next)
 
+;; TODO: Finish it!  We can move the active modes to a list of backed up modes,
+;; and have one "escape key" bound to a function that would restore the backup modes.
+
 (define-mode application-mode ()
     "Mode that forwards all keys to the platform port."
   ())

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -152,10 +152,11 @@ If FILE is \"-\", read from the standard input."
                       (load file :if-does-not-exist nil)))
     (error (c)
       ;; TODO: Handle warning from `echo'.
-      (log:warn "Error: we could not load the Lisp file ~a: ~a" file c)
-      (when interactive
-        (error "Could not load the lisp init file ~a: ~&~a" file c))
-      (echo "Error: we could not load the Lisp file ~a: ~a" file c))))
+      (let ((message "Error: we could not load the Lisp file ~a: ~a" ))
+        (log:warn message file c)
+        (when interactive
+          (error message file c))
+        (echo message file c)))))
 
 (define-command load-file ()
   "Load the provided lisp file.

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -82,7 +82,7 @@ Set to '-' to read standard input instead."))
                        (kill-interface *interface*))
     ;; Catch a C-c, don't print a full stacktrace.
     (#+sbcl sb-sys:interactive-interrupt
-     #+ccl  ccl:interrupt-signal-condition
+     #+ccl ccl:interrupt-signal-condition
      #+clisp system::simple-interrupt-condition
      #+ecl ext:interactive-interrupt
      #+allegro excl:interrupt-signal
@@ -172,7 +172,7 @@ If FILE is \"-\", read from the standard input."
   (load-lisp-file init-file))
 
 (defun default-startup (&optional urls)
-  "Make a window and load one buffer per URL in URLS.
+  "Make a window and load URLS in new buffers.
 This function is suitable as a `remote-interface' `startup-function'."
   (if urls
       (open-urls urls)

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -173,14 +173,8 @@ If FILE is \"-\", read from the standard input."
 (defun default-startup (&optional urls)
   "Make a window and load one buffer per URL in URLS.
 This function is suitable as a `remote-interface' `startup-function'."
-  ;; TODO: Why not making all buffers first, then create a window with the first
-  ;; buffer as argument?
   (if urls
-      (let ((buffer (nth-value 1 (make-window))))
-        (set-url (first urls) :buffer buffer)
-        (loop for url in (rest urls) do
-          (let ((buffer (make-buffer)))
-            (set-url url :buffer buffer))))
+      (open-urls urls)
       ;; TODO: Test if network is available.  If not, display help,
       ;; otherwise display start-page-url.
       (let ((window (rpc-window-make *interface*))

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -181,7 +181,7 @@ This function is suitable as a `remote-interface' `startup-function'."
       (let ((window (rpc-window-make *interface*))
             (buffer (help)))
         (window-set-active-buffer *interface* window buffer)))
-  (funcall (session-restore-function (last-active-window *interface*))))
+  (funcall (session-restore-function *interface*)))
 
 @export
 (defun start (&rest urls)

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -185,7 +185,8 @@ This function is suitable as a `remote-interface' `startup-function'."
       ;; otherwise display start-page-url.
       (let ((window (rpc-window-make *interface*))
             (buffer (help)))
-        (window-set-active-buffer *interface* window buffer))))
+        (window-set-active-buffer *interface* window buffer)))
+  (funcall (session-restore-function (last-active-window *interface*))))
 
 @export
 (defun start (&rest urls)

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -232,7 +232,7 @@ Finally, the `after-init-hook' of the `*interface*' is run."
 (define-key "C-l" #'set-url-current-buffer)
 (define-key "M-l" #'set-url-new-buffer)
 (define-key "C-m k" #'bookmark-delete)
-(define-key "C-t" #'make-visible-new-buffer)
+(define-key "C-t" #'make-buffer-focus)
 (define-key "C-m u" #'bookmark-url)
 (define-key "C-x C-k" #'delete-current-buffer)
 ;; TODO: Rename to inspect-variable?  Wouldn't describe-variable be more familiar?
@@ -241,7 +241,7 @@ Finally, the `after-init-hook' of the `*interface*' is run."
 (define-key "C-o" #'load-file)
 (define-key "C-h s" #'start-swank)
 (define-key "M-x" #'execute-command)
-(define-key "C-x 5 2" #'new-window)
+(define-key "C-x 5 2" #'make-window)
 (define-key "C-x 5 0" #'delete-window)
 ;; (define-key "C-x q" (lambda () (echo-dismiss (minibuffer *interface*)))) ; TODO: Seems obsolete?
 
@@ -254,7 +254,7 @@ Finally, the `after-init-hook' of the `*interface*' is run."
   "g b" #'switch-buffer
   "d" #'delete-buffer
   "D" #'delete-current-buffer
-  "B" #'make-visible-new-buffer
+  "B" #'make-buffer-focus
   "o" #'set-url-current-buffer
   "O" #'set-url-new-buffer
   "m u" #'bookmark-url
@@ -264,4 +264,4 @@ Finally, the `after-init-hook' of the `*interface*' is run."
   "C-h c" #'command-inspect
   "C-h s" #'start-swank
   ":" #'execute-command
-  "W" #'new-window)
+  "W" #'make-window)

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -45,7 +45,7 @@ If HOSTLIST has a `path', persist it locally."
 (defmethod load-to-memory ((hostlist hostlist))
   "Load hostlist.
 Auto-update file if older than UPDATE-INTERVAL seconds."
-  (if (and (ignore-errors (probe-file (path hostlist)))
+  (if (and (uiop:file-exists-p (path hostlist))
            (< (- (get-universal-time) (uiop:safe-file-write-date (path hostlist)))
               (update-interval hostlist)))
       (uiop:read-file-string (path hostlist))

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -115,3 +115,11 @@ Fall back on `resource-query-default'."
                               :is-known-type is-known-type
                               :mouse-button mouse-button
                               :modifiers modifiers)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(in-package :s-serialization)
+
+(defmethod serializable-slots ((object next/blocker-mode::blocker-mode))
+  "Discard hostlists which can get pretty big."
+  (delete 'next/blocker-mode::hostlists
+          (mapcar #'sb-mop:slot-definition-name (sb-mop:class-slots (class-of object)))))

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -84,4 +84,4 @@
                      (make-instance 'minibuffer
                                     :input-prompt "Open bookmark:"
                                     :completion-function 'bookmark-complete)))
-    (buffer-set-url :url url :buffer (active-buffer *interface*))))
+    (set-url url :buffer (active-buffer *interface*) :raw-url-p t)))

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -15,7 +15,7 @@
 
 (defun bookmark-complete (input)
   (let* ((db (sqlite:connect
-              (ensure-file-exists (bookmark-db-path (rpc-window-active *interface*))
+              (ensure-file-exists (bookmark-db-path *interface*)
                                   #'%initialize-bookmark-db)))
          (candidates
            (sqlite:execute-to-list
@@ -26,7 +26,7 @@
 
 (defun %bookmark-url (url)
   (let ((db (sqlite:connect
-             (ensure-file-exists (bookmark-db-path (rpc-window-active *interface*))
+             (ensure-file-exists (bookmark-db-path *interface*)
                                  #'%initialize-bookmark-db))))
     (sqlite:execute-non-query
      db "insert into bookmarks (url) values (?)" url)
@@ -36,7 +36,7 @@
   "Bookmark the currently opened page in the active buffer."
   (with-result (url (buffer-get-url))
     (let ((db (sqlite:connect
-               (ensure-file-exists (bookmark-db-path (rpc-window-active *interface*))
+               (ensure-file-exists (bookmark-db-path *interface*)
                                    #'%initialize-bookmark-db))))
       (sqlite:execute-non-query
        db "insert into bookmarks (url) values (?)" url)
@@ -56,7 +56,7 @@
                                          :input-prompt "Delete bookmark:"
                                          :completion-function 'bookmark-complete)))
     (let ((db (sqlite:connect
-               (ensure-file-exists (bookmark-db-path (rpc-window-active *interface*))
+               (ensure-file-exists (bookmark-db-path *interface*)
                                    #'%initialize-bookmark-db))))
       (sqlite:execute-non-query
        db "delete from bookmarks where url = ?" bookmark)

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -65,8 +65,8 @@ buffer to the start page."
   "Load INPUT-URL in BUFFER.
 URL is first transformed by `parse-url', then by BUFFER's `load-hook'."
   (let ((url (if raw-url-p
-                 (parse-url input-url)
-                 input-url)))
+                 input-url
+                 (parse-url input-url))))
     (setf (name buffer) url)
     (setf url (run-composed-hook (load-hook buffer) url))
     (rpc-buffer-load *interface* buffer url)))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -7,20 +7,11 @@
 (defmethod object-string ((buffer buffer))
   (format nil "~a  ~a" (name buffer) (title buffer)))
 
-(defun make-buffer (&key (name "default")
-                         default-modes)
+(define-command make-buffer (&key (name "default")
+                                  modes)
   "Create a new buffer.
-MODE is a mode symbol.
-This function is meant to be used on the Lisp side."
-  (rpc-buffer-make *interface* :name name :default-modes default-modes))
-
-(define-command new-buffer (&optional (name "default")
-                                      modes)
-  ;; TODO: Ask for modes interactively?
-  "Create a new buffer.
-This command is meant to be used interactively.
-See the `make-buffer' function for Lisp code."
-  (make-buffer :name name :default-modes modes))
+MODES is a list of mode symbols."
+  (rpc-buffer-make *interface* :name name :default-modes modes))
 
 (defun buffer-completion-fn ()
   (let ((buffers (alexandria:hash-table-values (buffers *interface*)))
@@ -40,8 +31,8 @@ See the `make-buffer' function for Lisp code."
                                        :completion-function (buffer-completion-fn))))
     (set-active-buffer *interface* buffer)))
 
-(define-command make-visible-new-buffer ()
-  "Make a new empty buffer with the default-new-buffer-url loaded."
+(define-command make-buffer-focus ()
+  "Switch to a new buffer showing default-new-buffer-url."
   (let ((buffer (make-buffer)))
     (set-active-buffer *interface* buffer)
     (set-url (default-new-buffer-url buffer) :buffer buffer)))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -70,18 +70,13 @@ buffer to the start page."
 
 @export
 (defun set-url (input-url &key (buffer (active-buffer *interface*))
-                            disable-history
                             raw-url-p)
   "Load INPUT-URL in BUFFER.
-URL is first transformed by `parse-url', then by BUFFER's `load-hook'.
-If DISABLE-HISTORY is non-nil, don't add the resulting URL to history."
+URL is first transformed by `parse-url', then by BUFFER's `load-hook'."
   (let ((url (if raw-url-p
                  (parse-url input-url)
                  input-url)))
     (setf (name buffer) url)
-    (unless disable-history
-      ;; TODO: Do we need this if we already save history in `did-commit-navigation'?
-      (history-typed-add input-url))
     (setf url (run-composed-hook (load-hook buffer) url))
     (rpc-buffer-load *interface* buffer url)))
 
@@ -102,7 +97,7 @@ If DISABLE-HISTORY is non-nil, don't add the resulting URL to history."
 (define-command reload-current-buffer ()
   "Reload current buffer."
   (with-result (url (buffer-get-url))
-    (set-url url :disable-history t)))
+    (set-url url)))
 
 (define-command set-url-new-buffer ()
   "Prompt the user for a URL and set it in a new active / visible

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -265,10 +265,12 @@
 ;; Warning: To specialize `did-commit-navigation' we must be in the right package.
 (in-package :next)
 (defmethod did-commit-navigation ((mode next/document-mode::document-mode) url)
-  (set-window-title *interface*
-                    (rpc-window-active *interface*)
-                    (active-buffer *interface*))
-  (next/document-mode::add-or-traverse-history mode url)
+  (let ((active-window (rpc-window-active *interface*)))
+    (set-window-title *interface*
+                      active-window
+                      (active-buffer active-window))
+    (next/document-mode::add-or-traverse-history mode url)
+    (funcall (session-store-function active-window)))
   (echo "Loading: ~a." url))
 
 (defmethod did-finish-navigation ((mode next/document-mode::document-mode) url)

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -1,7 +1,8 @@
 (uiop:define-package :next/document-mode
-    (:use :common-lisp :trivia :next)
+    (:use :common-lisp :trivia :next :annot.class)
   (:documentation "Mode for web pages"))
 (in-package :next/document-mode)
+(annot:enable-annot-syntax)
 ;; TODO: Rename "web-mode"?
 
 ;; TODO: Remove document-mode from special buffers (e.g. help).
@@ -10,6 +11,8 @@
 ;; changes in special buffers should open a new one.
 ;; Or else we require that all special-buffer-generting commands open a new buffer.
 
+@export
+@export-accessors
 (defclass node ()
   ((parent :accessor node-parent :initarg :parent :initform nil)
    (children :accessor node-children :initform nil)

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -23,7 +23,6 @@
     "Base mode for interacting with documents."
     ((active-history-node :accessor active-history-node :initarg :active-node
                           :initform (make-instance 'node :data "about:blank"))
-     (link-hints :accessor link-hints)
      (keymap-schemes
       :initform
       (let ((emacs-map (make-keymap))

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -282,7 +282,7 @@
                       active-window
                       (active-buffer active-window))
     (next/document-mode::add-or-traverse-history mode url)
-    (funcall (session-store-function active-window)))
+    (funcall (session-store-function *interface*)))
   (echo "Finished loading: ~a." url)
   ;; TODO: Wait some time before dismissing the minibuffer.
   (echo-dismiss))

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -265,16 +265,15 @@
 ;; Warning: To specialize `did-commit-navigation' we must be in the right package.
 (in-package :next)
 (defmethod did-commit-navigation ((mode next/document-mode::document-mode) url)
+  (echo "Loading: ~a." url))
+
+(defmethod did-finish-navigation ((mode next/document-mode::document-mode) url)
   (let ((active-window (rpc-window-active *interface*)))
     (set-window-title *interface*
                       active-window
                       (active-buffer active-window))
     (next/document-mode::add-or-traverse-history mode url)
     (funcall (session-store-function active-window)))
-  (echo "Loading: ~a." url))
-
-(defmethod did-finish-navigation ((mode next/document-mode::document-mode) url)
-  (log:debug mode url)
   (echo "Finished loading: ~a." url)
   ;; TODO: Wait some time before dismissing the minibuffer.
   (echo-dismiss))

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -2,6 +2,13 @@
     (:use :common-lisp :trivia :next)
   (:documentation "Mode for web pages"))
 (in-package :next/document-mode)
+;; TODO: Rename "web-mode"?
+
+;; TODO: Remove document-mode from special buffers (e.g. help).
+;; This is required because special buffers cannot be part of a history (and it breaks it).
+;; Bind C-l to set-url-new-buffer?  Wait: What if we click on a link?  url
+;; changes in special buffers should open a new one.
+;; Or else we require that all special-buffer-generting commands open a new buffer.
 
 (defclass node ()
   ((parent :accessor node-parent :initarg :parent :initform nil)

--- a/source/document-mode.lisp
+++ b/source/document-mode.lisp
@@ -149,7 +149,7 @@
                                                    ;; (mode (active-buffer *interface*))
                                                    ))))
     (when parent
-      (set-url (node-data parent) :disable-history t))))
+      (set-url (node-data parent)))))
 
 (define-command history-forwards (&optional (buffer (active-buffer *interface*)))
   "Move forwards in history selecting the first child."
@@ -159,7 +159,7 @@
                                    ;; (mode (active-buffer *interface*))
                                    ))))
     (unless (null children)
-      (set-url (node-data (nth 0 children)) :disable-history t))))
+      (set-url (node-data (nth 0 children))))))
 
 (defun history-forwards-completion-fn (&optional (mode (find-mode
                                                         (active-buffer *interface*)

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -11,8 +11,8 @@
   (let* ((download-buffer (or (find-buffer 'download-mode)
                               (make-buffer
                                :name "*Downloads*"
-                               :default-modes (cons 'download-mode
-                                                    (get-default 'buffer 'default-modes)))))
+                               :modes (cons 'download-mode
+                                            (get-default 'buffer 'default-modes)))))
          (contents (cl-markup:markup
                     (:h1 "Downloads")
                     (:p (:b "Directory: ") (namestring (or (download-directory *interface*)

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -4,9 +4,9 @@
 (in-package :next)
 (annot:enable-annot-syntax)
 
-(defvar *options* ()
+(defvar *options* '()
   "The list of command line options.")
-(defvar *free-args* ()
+(defvar *free-args* '()
   "The list of positional command line arguments.")
 
 @export

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -38,8 +38,8 @@
                                       :input-prompt "Inspect variable:")))
     (let* ((help-buffer (make-buffer
                          :name (concatenate 'string "HELP-" (symbol-name input))
-                         :default-modes (cons 'help-mode
-                                                (get-default 'buffer 'default-modes))))
+                         :modes (cons 'help-mode
+                                      (get-default 'buffer 'default-modes))))
            (help-contents (cl-markup:markup
                            (:h1 (symbol-name input))
                            (:p (documentation input 'variable))
@@ -59,8 +59,8 @@
                                       :completion-function 'function-complete)))
     (let* ((help-buffer (make-buffer
                          :name (str:concat "*Help-" (symbol-name input) "*")
-                         :default-modes (cons 'help-mode
-                                              (get-default 'buffer 'default-modes))))
+                         :modes (cons 'help-mode
+                                      (get-default 'buffer 'default-modes))))
            (help-contents (cl-markup:markup
                            (:h1 (symbol-name input))
                            (:h2 "Documentation")
@@ -90,8 +90,8 @@ This does not use an implicit PROGN to allow evaluating top-level expressions."
                                       :input-prompt "Evaluate Lisp:")))
     (let* ((result-buffer (make-buffer
                            :name (concatenate 'string "EVALUATION RESULT-" input)
-                           :default-modes (cons 'help-mode
-                                                (get-default 'buffer 'default-modes))))
+                           :modes (cons 'help-mode
+                                        (get-default 'buffer 'default-modes))))
            (results (handler-case
                         (mapcar #'write-to-string (evaluate input))
                       (error (c) (format nil "~a" c))))
@@ -111,8 +111,8 @@ This does not use an implicit PROGN to allow evaluating top-level expressions."
   "Print some help."
   (let* ((help-buffer (make-buffer
                        :name "*Help*"
-                       :default-modes (cons 'help-mode
-                                            (get-default 'buffer 'default-modes))))
+                       :modes (cons 'help-mode
+                                    (get-default 'buffer 'default-modes))))
          (help-contents
            (cl-markup:markup
             (:h1 "Getting started")

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -29,7 +29,7 @@
                    (some (lambda (window)
                            (history-db-path window))
                          (alexandria:hash-table-values (windows *interface*))))))
-    (if (probe-file path)
+    (if (uiop:file-exists-p path)
         path
         (ensure-file-exists path #'%initialize-history-db))))
 

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -21,14 +21,7 @@
 
 (defun ensure-history-db ()
   "Return the pathname of the history database."
-  (let* ((path (if (rpc-window-active *interface*)
-                   (history-db-path (rpc-window-active *interface*))
-                   ;; This additional window fallback should not be necessary
-                   ;; anymore now that `rpc-window-make' sets `last-active-window'
-                   ;; so that `rpc-window-active' always returns a result.
-                   (some (lambda (window)
-                           (history-db-path window))
-                         (alexandria:hash-table-values (windows *interface*))))))
+  (let* ((path (history-db-path *interface*)))
     (if (uiop:file-exists-p path)
         path
         (ensure-file-exists path #'%initialize-history-db))))

--- a/source/link-hint.lisp
+++ b/source/link-hint.lisp
@@ -117,7 +117,8 @@
   "Show a set of link hints, and go to the user inputted one in the
 currently active buffer."
   (query-hints "Go to link:" (selected-link)
-    (buffer-set-url :url selected-link :buffer (active-buffer *interface*))))
+    (set-url selected-link :buffer (active-buffer *interface*)
+             :raw-url-p t)))
 
 (define-deprecated-command go-anchor ()
   "Deprecated by `follow-hint'."
@@ -128,7 +129,8 @@ currently active buffer."
 buffer (not set to visible active buffer)."
   (query-hints "Open link in new buffer:" (selected-link)
     (let ((new-buffer (make-buffer)))
-      (buffer-set-url :url selected-link :buffer new-buffer))))
+      (set-url selected-link :buffer new-buffer
+               :raw-url-p t))))
 
 (define-deprecated-command go-anchor-new-buffer ()
   "Deprecated by `follow-hint-new-buffer'."
@@ -139,7 +141,7 @@ buffer (not set to visible active buffer)."
 visible active buffer."
   (query-hints "Go to link in new buffer:" (selected-link)
     (let ((new-buffer (make-buffer)))
-      (buffer-set-url :url selected-link :buffer new-buffer)
+      (set-url selected-link :buffer new-buffer :raw-url-p t)
       (set-active-buffer *interface* new-buffer))))
 
 (define-deprecated-command go-anchor-new-buffer-focus ()

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -110,3 +110,11 @@ If there is no corresponding keymap, return nil."
 
 (defmethod did-finish-navigation ((mode root-mode) url)
   url)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(in-package :s-serialization)
+
+(defmethod serializable-slots ((object next::root-mode))
+  "Discard keymaps which can be quite verbose."
+  (delete 'next::keymap-schemes
+          (mapcar #'sb-mop:slot-definition-name (sb-mop:class-slots (class-of object)))))

--- a/source/port.lisp
+++ b/source/port.lisp
@@ -28,7 +28,7 @@ as a string.")
 
 (defmethod path ((port port))
   (let ((p (port-accessor port 'path (name port))))
-    (if (probe-file p)
+    (if (uiop:file-exists-p p)
         (truename p)
         p)))
 
@@ -49,7 +49,7 @@ This is an acceptable value for the PATH slot of the PORT class."
     (or
      ;; look at the current directory.
      (loop for name in names
-        when (probe-file name)
+        when (uiop:file-exists-p name)
         return name)
 
      ;; look in the ports/ subdir.
@@ -59,7 +59,7 @@ This is an acceptable value for the PATH slot of the PORT class."
                               (file-namestring name)
                               (merge-pathnames (format nil "ports/~a/" dir-name)
                                                *default-pathname-defaults*))
-        when (probe-file file-in-subdir)
+        when (uiop:file-exists-p file-in-subdir)
         return file-in-subdir)
 
      ;; as a last resort, return "name".

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -813,7 +813,8 @@ First URL is focused."
                                   buffer))
                               urls))))
     (if (open-external-link-in-new-window-p *interface*)
-        (window-set-active-buffer *interface* (rpc-window-make *interface*) first-buffer)
+        (let ((window (rpc-window-make *interface*)))
+          (window-set-active-buffer *interface* window first-buffer))
         (set-active-buffer *interface* first-buffer))))
 
 @export
@@ -908,4 +909,7 @@ Deal with URL with the following rules:
                               (buffer buffer))
   "Set the active buffer for the active window."
   (let ((rpc-window-active (rpc-window-active interface)))
-    (window-set-active-buffer interface rpc-window-active buffer)))
+    (if rpc-window-active
+        (window-set-active-buffer interface rpc-window-active buffer)
+        (make-window buffer))
+    buffer))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -649,11 +649,14 @@ Run INTERFACE's `buffer-make-hook' over the created buffer before returning it."
   buffer)
 
 (defmethod %get-inactive-buffer ((interface remote-interface))
+  "Return inactive buffer or NIL if none."
   (let ((active-buffers
           (mapcar #'active-buffer
-                      (alexandria:hash-table-values (windows *interface*))))
+                  (alexandria:hash-table-values (windows *interface*))))
         (buffers (alexandria:hash-table-values (buffers *interface*))))
-    (alexandria:last-elt (set-difference buffers active-buffers))))
+    (match (set-difference buffers active-buffers)
+      ((guard diff diff)
+       (alexandria:last-elt diff)))))
 
 @export
 (defmethod rpc-buffer-delete ((interface remote-interface) (buffer buffer))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -593,11 +593,12 @@ Run INTERFACE's `buffer-make-hook' over the created buffer before returning it."
     (hooks:run-hook (hooks:object-hook interface 'buffer-make-hook) buffer)
     buffer))
 
-;; TODO: We already have buffer-load.  Rename this "init-dead-buffer".
 @export
-(defmethod rpc-load-buffer ((interface remote-interface) (buffer buffer))
+(defmethod rpc-init-dead-buffer ((interface remote-interface) (buffer buffer))
   "Create a webview for dead BUFFER.
-Run INTERFACE's `buffer-make-hook' over the created buffer before returning it."
+A \"dead buffer\" is a buffer that does not have an associated web view on the
+platform port.  Run INTERFACE's `buffer-make-hook' over the created buffer
+before returning it."
   (ensure-parent-exists (cookies-path buffer))
   (%rpc-send interface "buffer_make" (id buffer)
              `(("cookies-path" ,(namestring (cookies-path buffer)))))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -251,7 +251,7 @@ See `rpc-buffer-make'."
 
 (defmethod did-commit-navigation ((buffer buffer) url)
   (setf (name buffer) url)
-  (with-result (title (buffer-get-title))
+  (with-result (title (buffer-get-title :buffer buffer))
     (setf (title buffer) title))
   (dolist (mode (modes buffer))
     (did-commit-navigation mode url)))
@@ -568,7 +568,7 @@ proceeding."
                              (buffer buffer))
   "Set current window title to 'Next - TITLE - URL."
   (let ((url (name buffer)))
-    (with-result* ((title (buffer-get-title)))
+    (with-result* ((title (buffer-get-title :buffer buffer)))
       (setf title (if (str:emptyp title) "" title))
       (setf url (if (str:emptyp url) "<no url/name>" url))
       (rpc-window-set-title interface window
@@ -901,7 +901,8 @@ Deal with URL with the following rules:
 (defmethod active-buffer ((interface remote-interface))
   "Get the active buffer for the active window."
   (match (rpc-window-active interface)
-    ((guard w w) (active-buffer w))))
+    ((guard w w) (active-buffer w))
+    (_ (log:warn "No active window."))))
 
 ;; TODO: Prevent setting the minibuffer as the active buffer.
 @export

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -28,10 +28,6 @@ current URL or event messages.")
                              :documentation "The height of the minibuffer when closed.")
    (minibuffer-open-height :accessor minibuffer-open-height :initform 200
                            :documentation "The height of the minibuffer when open.")
-   (history-db-path :accessor history-db-path :initform (xdg-data-home "history.db")
-                    :documentation "The path where the system will create/save the history database.")
-   (bookmark-db-path :accessor bookmark-db-path :initform (xdg-data-home "bookmark.db")
-                     :documentation "The path where the system will create/save the bookmark database.")
    (window-set-active-buffer-hook :accessor window-set-active-buffer-hook :initform '() :type list
                                   :documentation "Hook run before `rpc-window-set-active-buffer' takes effect.
 The handlers take the window and the buffer as argument.")
@@ -276,6 +272,10 @@ stored.  Nil means use system default.")
                       :documentation "`local-time:timestamp' of when Next was started.")
    (init-time :initform 0.0 :type number
               :documentation "Init time in seconds.")
+   (history-db-path :accessor history-db-path :initform (xdg-data-home "history.db")
+                    :documentation "The path where the system will create/save the history database.")
+   (bookmark-db-path :accessor bookmark-db-path :initform (xdg-data-home "bookmark.db")
+                     :documentation "The path where the system will create/save the bookmark database.")
    (session-path :accessor session-path
                  :type string
                  :initform (xdg-data-home "session.lisp")

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -64,6 +64,7 @@ The handlers take the window as argument.")))
 Currently we store the list of current URLs of all buffers."
   (with-open-file (file (session-path (last-active-window *interface*))
                         :direction :output
+                        :if-does-not-exist :create
                         :if-exists :overwrite)
     (s-serialization:serialize-sexp
      (mapcar #'name (alexandria:hash-table-values (buffers *interface*)))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -53,54 +53,6 @@ The handlers take the window and the buffer as argument.")
                        :documentation "Hook run before `rpc-window-delete' takes effect.
 The handlers take the window as argument.")))
 
-;; TODO: Move session to `remote-interface'?
-;; TODO: How can we identify dead buffers?  Maybe with a nil ID?
-;; TODO: Use dead buffers for undo.
-
-;; TODO: Include version number in session and warn when not matching.
-;; TODO: Make sure keymaps, constructors, etc. are reset in buffers/modes.  See if constructor is called.  Make sure proxy value is kept.
-;; TODO: Make sure URLs are persisted when set from C-l.
-(defun store-sexp-session ()
-  "Store the current Next session to the last window's `session-path'.
-Currently we store the list of current URLs of all buffers."
-  (with-open-file (file (session-path (last-active-window *interface*))
-                        :direction :output
-                        :if-does-not-exist :create
-                        :if-exists :overwrite)
-    (s-serialization:serialize-sexp
-     (buffers *interface*)
-     ;; (mapcar #'name (alexandria:hash-table-values (buffers *interface*)))
-     file)))
-
-(defun restore-sexp-session ()
-  "Store the current Next session to the last window `session-path'.
-Currently we store the list of current URLs of all buffers."
-  (let ((buffers
-         (with-open-file (file (session-path (last-active-window *interface*))
-                               :direction :input
-                               :if-does-not-exist nil)
-           (when file
-             (s-serialization:deserialize-sexp
-              file)))))
-    (when (and (hash-table-p buffers)
-               (plusp (hash-table-count buffers)))
-      (log:info "Restoring ~a" (mapcar #'name (alexandria:hash-table-values buffers)))
-      ;; Delete the old buffers.
-      (maphash (lambda (id buffer)
-                 (declare (ignore id))
-                 (rpc-buffer-delete *interface* buffer))
-               buffers)
-      (setf (buffers *interface*) buffers)
-      ;; Make the new ones.
-      (maphash (lambda (id buffer)
-                 (declare (ignore id))
-                 (rpc-load-buffer *interface* buffer)
-                 (rpc-buffer-load *interface* buffer (name buffer)))
-               buffers)
-      ;; TODO: Switch to the last active buffer.  We probably need to serialize *interface*.
-      ;; Or else we could include `access-time' in the buffer class.
-      )))
-
 @export
 @export-accessors
 (defclass proxy ()

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -54,6 +54,12 @@ The handlers take the window and the buffer as argument.")
 The handlers take the window as argument.")))
 
 ;; TODO: Move session to `remote-interface'?
+;; TODO: How can we identify dead buffers?  Maybe with a nil ID?
+;; TODO: Use dead buffers for undo.
+
+;; TODO: Include version number in session and warn when not matching.
+;; TODO: Make sure keymaps, constructors, etc. are reset in buffers/modes.  See if constructor is called.  Make sure proxy value is kept.
+;; TODO: Make sure URLs are persisted when set from C-l.
 (defun store-sexp-session ()
   "Store the current Next session to the last window's `session-path'.
 Currently we store the list of current URLs of all buffers."
@@ -92,6 +98,7 @@ Currently we store the list of current URLs of all buffers."
                  (rpc-buffer-load *interface* buffer (name buffer)))
                buffers)
       ;; TODO: Switch to the last active buffer.  We probably need to serialize *interface*.
+      ;; Or else we could include `access-time' in the buffer class.
       )))
 
 @export

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -42,9 +42,9 @@ current URL or event messages.")
                            :documentation "The function which stores the session
 into `session-path'.")
    (session-restore-function :accessor session-restore-function
-                           :type function
-                           :initform #'restore-sexp-session
-                           :documentation "The function which restores the session
+                             :type function
+                             :initform #'restore-sexp-session
+                             :documentation "The function which restores the session
 into `session-path'.")
    (search-engines :accessor search-engines :initform '(("default" . "https://duckduckgo.com/?q=~a")
                                                         ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a"))
@@ -70,7 +70,7 @@ Currently we store the list of current URLs of all buffers."
      file)))
 
 (defun restore-sexp-session ()
-  "Store the current Next session to the last window's `session-path'.
+  "Store the current Next session to the last window `session-path'.
 Currently we store the list of current URLs of all buffers."
   (let ((url-list
          (with-open-file (file (session-path (last-active-window *interface*))
@@ -83,7 +83,7 @@ Currently we store the list of current URLs of all buffers."
       (make-buffers
        ;; TODO: Find a better way to clean up special buffers.  Or should we
        ;; restore them?
-       (delete-if (complement (alexandria:curry #'str:starts-with? "*"))
+       (delete-if (alexandria:curry #'str:starts-with? "*")
                   url-list)))))
 
 @export

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -594,6 +594,9 @@ Run INTERFACE's `buffer-make-hook' over the created buffer before returning it."
     (hooks:run-hook (hooks:object-hook interface 'buffer-make-hook) buffer)
     buffer))
 
+;; TODO: How can we identify dead buffers?  Maybe with a nil ID?  Or maybe a
+;; dead-buffer is just a buffer history.
+;; TODO: Use dead buffers for undo.
 @export
 (defmethod rpc-init-dead-buffer ((interface remote-interface) (buffer buffer))
   "Create a webview for dead BUFFER.

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -104,7 +104,6 @@ forwarded when no binding is found.")
                     ;; TODO: Store multiple key chords?  Maybe when implementing keyboard macros.
                     :documentation "The last key chords that were received for the current buffer.
 For now we only store the very last key chord.")
-   (view :accessor view :initarg :view)
    (resource-query-function :accessor resource-query-function
                             ;; TODO: What about having multiple functions?  And what about moving this to modes?
                             :initarg :resource-query-function

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -32,20 +32,6 @@ current URL or event messages.")
                     :documentation "The path where the system will create/save the history database.")
    (bookmark-db-path :accessor bookmark-db-path :initform (xdg-data-home "bookmark.db")
                      :documentation "The path where the system will create/save the bookmark database.")
-   (session-path :accessor session-path
-                 :type string
-                 :initform (xdg-data-home "session.lisp")
-                 :documentation "The path where the session is persisted.")
-   (session-store-function :accessor session-store-function
-                           :type function
-                           :initform #'store-sexp-session
-                           :documentation "The function which stores the session
-into `session-path'.")
-   (session-restore-function :accessor session-restore-function
-                             :type function
-                             :initform #'restore-sexp-session
-                             :documentation "The function which restores the session
-into `session-path'.")
    (window-set-active-buffer-hook :accessor window-set-active-buffer-hook :initform '() :type list
                                   :documentation "Hook run before `rpc-window-set-active-buffer' takes effect.
 The handlers take the window and the buffer as argument.")
@@ -290,6 +276,21 @@ stored.  Nil means use system default.")
                       :documentation "`local-time:timestamp' of when Next was started.")
    (init-time :initform 0.0 :type number
               :documentation "Init time in seconds.")
+   (session-path :accessor session-path
+                 :type string
+                 :initform (xdg-data-home "session.lisp")
+                 :documentation "The path where the session is persisted.")
+   (session-store-function :accessor session-store-function
+                           :type function
+                           :initform #'store-sexp-session
+                           :documentation "The function which stores the session
+into `session-path'.")
+   (session-restore-function :accessor session-restore-function
+                             :type function
+                             :initform #'restore-sexp-session
+                             :documentation "The function which restores the session
+into `session-path'.")
+   ;; Hooks follow:
    (after-init-hook :accessor after-init-hook :initform '() :type list
                     :documentation "Hook run after both `*interface*' and the
 platform port have started.  The handlers take no argument.")

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -81,8 +81,10 @@ Currently we store the list of current URLs of all buffers."
               file)))))
     (when url-list
       (make-buffers
-       ;; (delete-if (alexandria:curry #'string= "*Help*") url-list)
-       url-list))))
+       ;; TODO: Find a better way to clean up special buffers.  Or should we
+       ;; restore them?
+       (delete-if (complement (alexandria:curry #'str:starts-with? "*"))
+                  url-list)))))
 
 @export
 @export-accessors
@@ -287,6 +289,13 @@ by Next when the user session dbus instance is not available.")
    (last-active-window :accessor last-active-window :initform nil)
    (buffers :accessor buffers :initform (make-hash-table :test #'equal))
    (total-buffer-count :accessor total-buffer-count :initform 0)
+   (startup-function :accessor startup-function
+                     :type function
+                     :initform #'default-startup
+                     :documentation "The function run on startup.  It takes a
+list of URLs (strings) as argument (the command line positional arguments).  It
+is run after the platform port has been initialized and after the
+`after-init-hook' has run.")
    (start-page-url :accessor start-page-url :initform "https://next.atlas.engineer/quickstart"
                    :documentation "The URL of the first buffer opened by Next when started.")
    (open-external-link-in-new-window-p :accessor open-external-link-in-new-window-p :initform nil

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -62,25 +62,37 @@ Currently we store the list of current URLs of all buffers."
                         :if-does-not-exist :create
                         :if-exists :overwrite)
     (s-serialization:serialize-sexp
-     (mapcar #'name (alexandria:hash-table-values (buffers *interface*)))
+     (buffers *interface*)
+     ;; (mapcar #'name (alexandria:hash-table-values (buffers *interface*)))
      file)))
 
 (defun restore-sexp-session ()
   "Store the current Next session to the last window `session-path'.
 Currently we store the list of current URLs of all buffers."
-  (let ((url-list
+  (let ((buffers
          (with-open-file (file (session-path (last-active-window *interface*))
                                :direction :input
                                :if-does-not-exist nil)
            (when file
              (s-serialization:deserialize-sexp
               file)))))
-    (when url-list
-      (open-urls
-       ;; TODO: Find a better way to clean up special buffers.  Or should we
-       ;; restore them?
-       (delete-if (alexandria:curry #'str:starts-with? "*")
-                  url-list)))))
+    (when (and (hash-table-p buffers)
+               (plusp (hash-table-count buffers)))
+      (log:info "Restoring ~a" (mapcar #'name (alexandria:hash-table-values buffers)))
+      ;; Delete the old buffers.
+      (maphash (lambda (id buffer)
+                 (declare (ignore id))
+                 (rpc-buffer-delete *interface* buffer))
+               buffers)
+      (setf (buffers *interface*) buffers)
+      ;; Make the new ones.
+      (maphash (lambda (id buffer)
+                 (declare (ignore id))
+                 (rpc-load-buffer *interface* buffer)
+                 (rpc-buffer-load *interface* buffer (name buffer)))
+               buffers)
+      ;; TODO: Switch to the last active buffer.  We probably need to serialize *interface*.
+      )))
 
 @export
 @export-accessors
@@ -621,6 +633,20 @@ Run INTERFACE's `buffer-make-hook' over the created buffer before returning it."
     (initialize-modes buffer)
     (hooks:run-hook (hooks:object-hook interface 'buffer-make-hook) buffer)
     buffer))
+
+;; TODO: We already have buffer-load.  Rename this "init-dead-buffer".
+@export
+(defmethod rpc-load-buffer ((interface remote-interface) (buffer buffer))
+  "Create a webview for dead BUFFER.
+Run INTERFACE's `buffer-make-hook' over the created buffer before returning it."
+  (ensure-parent-exists (cookies-path buffer))
+  (%rpc-send interface "buffer_make" (id buffer)
+             `(("cookies-path" ,(namestring (cookies-path buffer)))))
+  ;; Modes might require that buffer exists, so we need to initialize them
+  ;; after it has been created on the platform port.
+  (initialize-modes buffer)
+  (hooks:run-hook (hooks:object-hook interface 'buffer-make-hook) buffer)
+  buffer)
 
 (defmethod %get-inactive-buffer ((interface remote-interface))
   (let ((active-buffers

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -46,11 +46,6 @@ into `session-path'.")
                              :initform #'restore-sexp-session
                              :documentation "The function which restores the session
 into `session-path'.")
-   (search-engines :accessor search-engines :initform '(("default" . "https://duckduckgo.com/?q=~a")
-                                                        ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a"))
-                   :documentation "An association list of all the search engines you can use in the minibuffer.
-The 'default' engine is used when the query is not a valid URL, or the first
-keyword is not recognized.")
    (window-set-active-buffer-hook :accessor window-set-active-buffer-hook :initform '() :type list
                                   :documentation "Hook run before `rpc-window-set-active-buffer' takes effect.
 The handlers take the window and the buffer as argument.")
@@ -303,6 +298,12 @@ is run after the platform port has been initialized and after the
                                        :documentation "When open links from an external program, or
 when C-cliking on a URL, decide whether to open in a new
 window or not.")
+   (search-engines :accessor search-engines
+                   :initform '(("default" . "https://duckduckgo.com/?q=~a")
+                               ("wiki" . "https://en.wikipedia.org/w/index.php?search=~a"))
+                   :documentation "An association list of all the search engines
+you can use in the minibuffer.  The 'default' engine is used when the query is
+not a valid URL, or the first keyword is not recognized.")
    (key-chord-stack :accessor key-chord-stack :initform '()
                     :documentation "A stack that keeps track of the key chords a user has inputted.")
    (downloads :accessor downloads :initform '()

--- a/source/serialization.lisp
+++ b/source/serialization.lisp
@@ -1,72 +1,9 @@
 (in-package :s-serialization)
 
 ;; TODO: Report upstream.
+;; https://github.com/40ants/cl-prevalence/issues/2
 (defmethod serialize-sexp-internal ((object pathname) stream serialization-state)
   "Serialize pathname OBJECT to it's printed representation starting with #P.
 Note: Function serialization is not part of the original cl-prevalence."
   (declare (ignore serialization-state))
   (prin1 object stream))
-
-;; TODO: Remove the fixes below:
-
-;; TODO: Test named functions + lambdas.
-;; TODO: Report upstream if good enough.
-(defmethod serialize-sexp-internal ((object function) stream serialization-state)
-  "Serialize function OBJECT.
-If the function is named FOO, serialized is to \"#'FOO\".
-Note: Function serialization is not part of the original cl-prevalence."
-  (declare (ignore serialization-state))
-  (let ((function-symbol (nth-value 2 (function-lambda-expression object))))
-    (unless (symbolp function-symbol)
-      ;; (error "Cannot serialize anonymous functions (lambdas)")
-      (setf function-symbol nil))
-    (write-string "(:FUNCTION . " stream)
-    (print-symbol function-symbol stream)
-    (write-string ")" stream)))
-
-;; The following adds function support to deserialization:
-(defun deserialize-sexp-internal (sexp deserialized-objects)
-  (if (atom sexp)
-      sexp
-      (ecase (first sexp)
-        (:sequence (destructuring-bind (id &key class size elements) (rest sexp)
-                     (let ((sequence (make-sequence class size)))
-                       (setf (gethash id deserialized-objects) sequence)
-                       (map-into sequence
-                                 #'(lambda (x) (deserialize-sexp-internal x deserialized-objects))
-                                 elements))))
-        (:hash-table (destructuring-bind (id &key test size rehash-size rehash-threshold entries) (rest sexp)
-                       (let ((hash-table (make-hash-table :size size
-                                                          :test test
-                                                          :rehash-size rehash-size
-                                                          :rehash-threshold rehash-threshold)))
-                         (setf (gethash id deserialized-objects) hash-table)
-                         (dolist (entry entries)
-                           (setf (gethash (deserialize-sexp-internal (first entry) deserialized-objects) hash-table)
-                                 (deserialize-sexp-internal (rest entry) deserialized-objects)))
-                         hash-table)))
-        (:object (destructuring-bind (id &key class slots) (rest sexp)
-                   (let ((object (make-instance class)))
-                     (setf (gethash id deserialized-objects) object)
-                     (dolist (slot slots)
-                       (when (slot-exists-p object (first slot))
-                         (setf (slot-value object (first slot))
-                               (deserialize-sexp-internal (rest slot) deserialized-objects))))
-                     object)))
-        (:struct (destructuring-bind (id &key class slots) (rest sexp)
-                   (let ((object (funcall (intern (concatenate 'string "MAKE-" (symbol-name class))
-                                                  (symbol-package class)))))
-                     (setf (gethash id deserialized-objects) object)
-                     (dolist (slot slots)
-                       (when (slot-exists-p object (first slot))
-                         (setf (slot-value object (first slot))
-                               (deserialize-sexp-internal (rest slot) deserialized-objects))))
-                     object)))
-        (:cons (destructuring-bind (id cons-car cons-cdr) (rest sexp)
-                 (let ((conspair (cons nil nil)))
-                   (setf (gethash id deserialized-objects)
-                         conspair)
-                   (rplaca conspair (deserialize-sexp-internal cons-car deserialized-objects))
-                   (rplacd conspair (deserialize-sexp-internal cons-cdr deserialized-objects)))))
-        (:ref (gethash (rest sexp) deserialized-objects))
-        (:function (symbol-function (rest sexp))))))

--- a/source/serialization.lisp
+++ b/source/serialization.lisp
@@ -1,0 +1,73 @@
+(in-package :s-serialization)
+
+(defun ignoring (&rest args)
+  (declare (ignore args)))
+
+;; TODO: Test named functions + lambdas.
+;; TODO: Report upstream if good enough.
+(defmethod serialize-sexp-internal ((object function) stream serialization-state)
+  "Serialize function OBJECT.
+If the function is named FOO, serialized is to \"#'FOO\".
+Note: Function serialization is not part of the original cl-prevalence."
+  (declare (ignore serialization-state))
+  (let ((function-symbol (nth-value 2 (function-lambda-expression object))))
+    (unless (symbolp function-symbol)
+      ;; TODO: Error out if we get a lambda?
+      (setf function-symbol 's-serialization::ignoring))
+    (write-string "(:FUNCTION . " stream)
+    (print-symbol function-symbol stream)
+    (write-string ")" stream)))
+
+;; TODO: Report upstream.
+(defmethod serialize-sexp-internal ((object pathname) stream serialization-state)
+  "Serialize pathname OBJECT to it's printed representation starting with #P.
+Note: Function serialization is not part of the original cl-prevalence."
+  (declare (ignore serialization-state))
+  (prin1 object stream))
+
+;; The following adds function support to deserialization:
+(defun deserialize-sexp-internal (sexp deserialized-objects)
+  (if (atom sexp)
+      sexp
+      (ecase (first sexp)
+        (:sequence (destructuring-bind (id &key class size elements) (rest sexp)
+                     (let ((sequence (make-sequence class size)))
+                       (setf (gethash id deserialized-objects) sequence)
+                       (map-into sequence
+                                 #'(lambda (x) (deserialize-sexp-internal x deserialized-objects))
+                                 elements))))
+        (:hash-table (destructuring-bind (id &key test size rehash-size rehash-threshold entries) (rest sexp)
+                       (let ((hash-table (make-hash-table :size size
+                                                          :test test
+                                                          :rehash-size rehash-size
+                                                          :rehash-threshold rehash-threshold)))
+                         (setf (gethash id deserialized-objects) hash-table)
+                         (dolist (entry entries)
+                           (setf (gethash (deserialize-sexp-internal (first entry) deserialized-objects) hash-table)
+                                 (deserialize-sexp-internal (rest entry) deserialized-objects)))
+                         hash-table)))
+        (:object (destructuring-bind (id &key class slots) (rest sexp)
+                   (let ((object (make-instance class)))
+                     (setf (gethash id deserialized-objects) object)
+                     (dolist (slot slots)
+                       (when (slot-exists-p object (first slot))
+                         (setf (slot-value object (first slot))
+                               (deserialize-sexp-internal (rest slot) deserialized-objects))))
+                     object)))
+        (:struct (destructuring-bind (id &key class slots) (rest sexp)
+                   (let ((object (funcall (intern (concatenate 'string "MAKE-" (symbol-name class))
+                                                  (symbol-package class)))))
+                     (setf (gethash id deserialized-objects) object)
+                     (dolist (slot slots)
+                       (when (slot-exists-p object (first slot))
+                         (setf (slot-value object (first slot))
+                               (deserialize-sexp-internal (rest slot) deserialized-objects))))
+                     object)))
+        (:cons (destructuring-bind (id cons-car cons-cdr) (rest sexp)
+                 (let ((conspair (cons nil nil)))
+                   (setf (gethash id deserialized-objects)
+                         conspair)
+                   (rplaca conspair (deserialize-sexp-internal cons-car deserialized-objects))
+                   (rplacd conspair (deserialize-sexp-internal cons-cdr deserialized-objects)))))
+        (:ref (gethash (rest sexp) deserialized-objects))
+        (:function (symbol-function (rest sexp))))))

--- a/source/serialization.lisp
+++ b/source/serialization.lisp
@@ -1,8 +1,5 @@
 (in-package :s-serialization)
 
-(defun ignoring (&rest args)
-  (declare (ignore args)))
-
 ;; TODO: Test named functions + lambdas.
 ;; TODO: Report upstream if good enough.
 (defmethod serialize-sexp-internal ((object function) stream serialization-state)
@@ -12,8 +9,8 @@ Note: Function serialization is not part of the original cl-prevalence."
   (declare (ignore serialization-state))
   (let ((function-symbol (nth-value 2 (function-lambda-expression object))))
     (unless (symbolp function-symbol)
-      ;; TODO: Error out if we get a lambda?
-      (setf function-symbol 's-serialization::ignoring))
+      ;; (error "Cannot serialize anonymous functions (lambdas)")
+      (setf function-symbol nil))
     (write-string "(:FUNCTION . " stream)
     (print-symbol function-symbol stream)
     (write-string ")" stream)))

--- a/source/serialization.lisp
+++ b/source/serialization.lisp
@@ -1,5 +1,14 @@
 (in-package :s-serialization)
 
+;; TODO: Report upstream.
+(defmethod serialize-sexp-internal ((object pathname) stream serialization-state)
+  "Serialize pathname OBJECT to it's printed representation starting with #P.
+Note: Function serialization is not part of the original cl-prevalence."
+  (declare (ignore serialization-state))
+  (prin1 object stream))
+
+;; TODO: Remove the fixes below:
+
 ;; TODO: Test named functions + lambdas.
 ;; TODO: Report upstream if good enough.
 (defmethod serialize-sexp-internal ((object function) stream serialization-state)
@@ -14,13 +23,6 @@ Note: Function serialization is not part of the original cl-prevalence."
     (write-string "(:FUNCTION . " stream)
     (print-symbol function-symbol stream)
     (write-string ")" stream)))
-
-;; TODO: Report upstream.
-(defmethod serialize-sexp-internal ((object pathname) stream serialization-state)
-  "Serialize pathname OBJECT to it's printed representation starting with #P.
-Note: Function serialization is not part of the original cl-prevalence."
-  (declare (ignore serialization-state))
-  (prin1 object stream))
 
 ;; The following adds function support to deserialization:
 (defun deserialize-sexp-internal (sexp deserialized-objects)

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -12,7 +12,6 @@ instance of Next."
   (delete-if #'null (mapcar #'buffer-history
                             (alexandria:hash-table-values (buffers *interface*)))))
 
-;; TODO: Move session to `remote-interface'?
 ;; TODO: How can we identify dead buffers?  Maybe with a nil ID?  Or maybe a
 ;; dead-buffer is just a buffer history.
 ;; TODO: Use dead buffers for undo.
@@ -25,7 +24,7 @@ Currently we store the list of current URLs of all buffers."
   ;; TODO: Should we persist keymaps, constructors, etc.?  For instance, should
   ;; we restore the proxy value?  It may be wiser to let the user configure
   ;; whitelitss / blacklists instead.  It's also easier
-  (with-open-file (file (session-path (last-active-window *interface*))
+  (with-open-file (file (session-path *interface*)
                         :direction :output
                         :if-does-not-exist :create
                         :if-exists :overwrite)

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -17,7 +17,6 @@ instance of Next."
         (delete-if #'null (mapcar #'buffer-history
                                   (alexandria:hash-table-values (buffers *interface*))))))
 
-;; TODO: Make sure URLs are persisted when set from C-l.
 (defun store-sexp-session ()
   "Store the current Next session to the last window's `session-path'.
 Currently we store the list of current URLs of all buffers."

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -17,7 +17,6 @@ instance of Next."
         (delete-if #'null (mapcar #'buffer-history
                                   (alexandria:hash-table-values (buffers *interface*))))))
 
-;; TODO: Pretty-print the session.
 ;; TODO: Make sure URLs are persisted when set from C-l.
 (defun store-sexp-session ()
   "Store the current Next session to the last window's `session-path'.
@@ -29,9 +28,12 @@ Currently we store the list of current URLs of all buffers."
                         :direction :output
                         :if-does-not-exist :create
                         :if-exists :overwrite)
-    (s-serialization:serialize-sexp
-     (session-data)
-     file)))
+    ;; We READ the output of serialize-sexp to make it more human-readable.
+    (format file
+            "~s"
+            (with-input-from-string (in (with-output-to-string (out)
+                                          (s-serialization:serialize-sexp (session-data) out)))
+              (read in)))))
 
 (defun restore-sexp-session ()
   "Store the current Next session to the last window `session-path'.

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -1,0 +1,62 @@
+(in-package :next)
+
+(defun buffer-history (buffer)
+  "Return the buffer history of BUFFER."
+  (match (find-mode buffer 'document-mode)
+    ((guard m m) (next/document-mode:active-history-node m))))
+
+(defun session-data ()
+  "Return the data that needs to be serialized.
+This data can be used to restore the session later, e.g. when starting a new
+instance of Next."
+  (delete-if #'null (mapcar #'buffer-history
+                            (alexandria:hash-table-values (buffers *interface*)))))
+
+;; TODO: Move session to `remote-interface'?
+;; TODO: How can we identify dead buffers?  Maybe with a nil ID?  Or maybe a
+;; dead-buffer is just a buffer history.
+;; TODO: Use dead buffers for undo.
+
+;; TODO: Include version number in session and warn when not matching.
+;; TODO: Make sure URLs are persisted when set from C-l.
+(defun store-sexp-session ()
+  "Store the current Next session to the last window's `session-path'.
+Currently we store the list of current URLs of all buffers."
+  ;; TODO: Should we persist keymaps, constructors, etc.?  For instance, should
+  ;; we restore the proxy value?  It may be wiser to let the user configure
+  ;; whitelitss / blacklists instead.  It's also easier
+  (with-open-file (file (session-path (last-active-window *interface*))
+                        :direction :output
+                        :if-does-not-exist :create
+                        :if-exists :overwrite)
+    (s-serialization:serialize-sexp
+     (session-data)
+     file)))
+
+(defun restore-sexp-session ()
+  "Store the current Next session to the last window `session-path'.
+Currently we store the list of current URLs of all buffers."
+  (let ((buffer-histories
+         (with-open-file (file (session-path (last-active-window *interface*))
+                               :direction :input
+                               :if-does-not-exist nil)
+           (when file
+             (s-serialization:deserialize-sexp
+              file)))))
+    (when buffer-histories
+      (log:info "Restoring ~a" (mapcar #'next/document-mode:node-data buffer-histories))
+      ;; Delete the old buffers?
+      ;; (maphash (lambda (id buffer)
+      ;;            (declare (ignore id))
+      ;;            (rpc-buffer-delete *interface* buffer))
+      ;;          buffers)
+      ;; Make the new ones.
+      ;; TODO: Add function `make-buffer-from-history' to document-mode?
+      (loop for history in buffer-histories
+            for buffer = (make-buffer)
+            for mode = (find-mode buffer 'document-mode)
+            do (set-url (next/document-mode:node-data history) :buffer buffer)
+            do (setf (next/document-mode:active-history-node mode) history))
+      ;; TODO: Switch to the last active buffer.  We probably need to serialize *interface*.
+      ;; Or else we could include `access-time' in the buffer class.
+      )))

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -9,14 +9,15 @@
   "Return the data that needs to be serialized.
 This data can be used to restore the session later, e.g. when starting a new
 instance of Next."
-  (delete-if #'null (mapcar #'buffer-history
-                            (alexandria:hash-table-values (buffers *interface*)))))
+  ;; TODO: What should the session root be?  A hash-table?  A plist?
+  ;; For now, it's just a simple list where the first element is the version.
+  ;; Maybe not future-proof, but it's unclear that session structure will ever
+  ;; change much.
+  (list +version+
+        (delete-if #'null (mapcar #'buffer-history
+                                  (alexandria:hash-table-values (buffers *interface*))))))
 
-;; TODO: How can we identify dead buffers?  Maybe with a nil ID?  Or maybe a
-;; dead-buffer is just a buffer history.
-;; TODO: Use dead buffers for undo.
-
-;; TODO: Include version number in session and warn when not matching.
+;; TODO: Pretty-print the session.
 ;; TODO: Make sure URLs are persisted when set from C-l.
 (defun store-sexp-session ()
   "Store the current Next session to the last window's `session-path'.
@@ -35,27 +36,33 @@ Currently we store the list of current URLs of all buffers."
 (defun restore-sexp-session ()
   "Store the current Next session to the last window `session-path'.
 Currently we store the list of current URLs of all buffers."
-  (let ((buffer-histories
-         (with-open-file (file (session-path (last-active-window *interface*))
-                               :direction :input
-                               :if-does-not-exist nil)
-           (when file
-             (s-serialization:deserialize-sexp
-              file)))))
-    (when buffer-histories
-      (log:info "Restoring ~a" (mapcar #'next/document-mode:node-data buffer-histories))
-      ;; Delete the old buffers?
-      ;; (maphash (lambda (id buffer)
-      ;;            (declare (ignore id))
-      ;;            (rpc-buffer-delete *interface* buffer))
-      ;;          buffers)
-      ;; Make the new ones.
-      ;; TODO: Add function `make-buffer-from-history' to document-mode?
-      (loop for history in buffer-histories
-            for buffer = (make-buffer)
-            for mode = (find-mode buffer 'document-mode)
-            do (set-url (next/document-mode:node-data history) :buffer buffer)
-            do (setf (next/document-mode:active-history-node mode) history))
-      ;; TODO: Switch to the last active buffer.  We probably need to serialize *interface*.
-      ;; Or else we could include `access-time' in the buffer class.
-      )))
+  (let ((session-path (session-path *interface*)))
+    (handler-case
+        (match (with-open-file (file session-path
+                                     :direction :input
+                                     :if-does-not-exist nil)
+                 (when file
+                   (s-serialization:deserialize-sexp
+                    file)))
+          ((list version buffer-histories)
+           (unless (string= version +version+)
+             (log:warn "Session version ~s differs from current version ~s" version +version+))
+           (when buffer-histories
+             (log:info "Restoring ~a" (mapcar #'next/document-mode:node-data buffer-histories))
+             ;; Delete the old buffers?
+             ;; (maphash (lambda (id buffer)
+             ;;            (declare (ignore id))
+             ;;            (rpc-buffer-delete *interface* buffer))
+             ;;          buffers)
+             ;; Make the new ones.
+             ;; TODO: Replace the loop with a function `make-buffer-from-history' in document-mode?
+             (loop for history in buffer-histories
+                   for buffer = (make-buffer)
+                   for mode = (find-mode buffer 'document-mode)
+                   do (set-url (next/document-mode:node-data history) :buffer buffer)
+                   do (setf (next/document-mode:active-history-node mode) history))
+             ;; TODO: Switch to the last active buffer.  We probably need to serialize *interface*.
+             ;; Or else we could include `access-time' in the buffer class.
+             )))
+      (error (c)
+        (log:warn "Failed to restore session from ~a: ~a" session-path c)))))

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -57,7 +57,9 @@ Otherwise, build a search query with the default search engine."
 
 (defun generate-search-query (search-string search-url)
   (let* ((encoded-search-string
-           (cl-ppcre:regex-replace-all " +" search-string "+"))
+           ;; We need to encode the search string to escape special characters.
+           ;; Besides, we separate search patterns by a "+".
+           (cl-ppcre:regex-replace-all "(%20)+" (quri:url-encode search-string) "+"))
          (url (format nil search-url encoded-search-string)))
     url))
 

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -37,7 +37,7 @@ Otherwise, build a search query with the default search engine."
                   (not (string= "file" recognized-scheme)))
              input-url)
             ((or (string= "file" recognized-scheme)
-                 (probe-file input-url))
+                 (uiop:file-exists-p input-url))
              (if (string= "file" recognized-scheme)
                  input-url
                  (format nil "file://~a"
@@ -187,7 +187,7 @@ FILE-NAME is appended to the result."
 (defun ensure-file-exists (path &optional (init-function))
   "Create file pointed by PATH if it does not exists.  Return PATH's truename.
 When non-nil, INIT-FUNCTION is used to create the file, else the file will be empty."
-  (unless (probe-file path)
+  (unless (uiop:file-exists-p path)
     (if init-function
         (funcall init-function path)
         (close (open (ensure-parent-exists path) :direction :probe :if-does-not-exist :create))))

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -21,11 +21,10 @@ If the input starts with an uri scheme, open it as is.
 If the input is actually a file path, open it.
 Suppose the user omitted the scheme: if the input prefixed by 'https://' gives a valid uri, go to it.
 Otherwise, build a search query with the default search engine."
-  (let* ((window (rpc-window-active *interface*))
-         (engine (assoc (first (str:split " " input-url))
-                        (search-engines window) :test #'string=))
+  (let* ((engine (assoc (first (str:split " " input-url))
+                        (search-engines *interface*) :test #'string=))
          (default (assoc "default"
-                         (search-engines window) :test #'string=)))
+                         (search-engines *interface*) :test #'string=)))
     (if engine
         (generate-search-query
          (subseq input-url

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -228,7 +228,10 @@ The second value is the initfunction."
 @export
 (defun (setf get-default) (value class-name slot-name)
   "Set default value of SLOT-NAME from CLASS-NAME.
-Return VALUE."
+Return VALUE.
+
+This only changes the default value for future instances.  Existing instances
+won't be affected."
   ;; Warning: This is quite subtle: the :initform and :initfunction are tightly
   ;; coupled, it seems that both must be changed together.  We need to change
   ;; the class-slots and not the class-direct-slots.  TODO: Explain why.
@@ -239,7 +242,10 @@ Return VALUE."
 
 (defun add-to-default-list (value class-name slot-name)
   "Add VALUE to the list SLOT-NAME from CLASS-NAME.
-If VALUE is already present, move it to the head of the list."
+If VALUE is already present, move it to the head of the list.
+
+This only changes the default value for future instances.  Existing instances
+won't be affected."
   (setf (get-default class-name slot-name)
         (remove-duplicates (cons value
                                  (get-default class-name slot-name))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -18,7 +18,7 @@
     (window-set-active-buffer *interface* window buffer)
     (values window buffer)))
 
-(define-command new-window ()
+(define-command new-window ()           ; TODO: This function is not needed anymore, turn `make-window' to a command instead.
   "Create a new window.
 This command is meant to be used interactively.
 For Lisp code, see `make-window'."

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -11,18 +11,9 @@
           (active-window
            (echo "Can't delete sole window.")))))
 
-(defun make-window (&optional buffer)
+(define-command make-window (&optional buffer)
   "Create a new window."
   (let ((window (rpc-window-make *interface*))
         (buffer (or buffer (make-buffer))))
-    (window-set-active-buffer *interface* window buffer)
-    (values window buffer)))
-
-(define-command new-window ()           ; TODO: This function is not needed anymore, turn `make-window' to a command instead.
-  "Create a new window.
-This command is meant to be used interactively.
-For Lisp code, see `make-window'."
-  (let ((window (rpc-window-make *interface*))
-        (buffer (make-buffer)))
     (window-set-active-buffer *interface* window buffer)
     (values window buffer)))

--- a/tests/test-utility.lisp
+++ b/tests/test-utility.lisp
@@ -90,6 +90,8 @@
   (is "http://[1:0:0:2::3:0.]/" (first (next::fuzzy-match "[" '("test1"
                                                                 "http://[1:0:0:2::3:0.]/"
                                                                 "test2")))
-      "match regex meta-characters"))
+      "match regex meta-characters")
+  (is "https://duckduckgo.com/?q=*spurious*" (next::parse-url "*spurious*")
+      "ignore wildcards"))
 
 (finalize)


### PR DESCRIPTION
Draft for now.

I can restore URLs on startup.  Hooray! :)

I've extracted the startup precedure to make it configurable by the user.
The session "store" and "restore" functions can be customized.

Before proceding, I need to clean up parts of the code:

- buffer-set-url is used in places, like following link hints, which bypasses the `set-url` function.  I believe there should be only one entry point for URL change.  I suggest renaming buffer-set-url to `%set-url` and using it only from `set-url`.
- We could add an option to `set-url` to not call `parse-url`, e.g. `:raw-url-p`.
- I want to delete new-window and new-buffer.
- I want to merge `make-buffers` into `make-buffer`.

Question:

- Should the session persistence functions be per window or per interface?  Considering a session persistence might save information about windows, maybe it would make more sense to store it in the remote-interface class.  But what about "private windows" then?