### PR TITLE
Fix "The value 31 is not of type SYMBOL" error at startup.

### DIFF
--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -136,7 +136,7 @@ platform ports might support this.")
                            ;; TODO: The highest integer value is non-standard,
                            ;; so the following might depend on the web renderer.
                            ;; https://developer.mozilla.org/en-US/docs/Web/CSS/integer#Syntax
-                           :z-index (1- (expt 2 31))))
+                           :z-index #.(1- (expt 2 31))))
               :documentation "The style of the boxes, e.g. link hints.")
    (proxy :initform nil :type :proxy
           :documentation "Proxy for buffer.")


### PR DESCRIPTION
Pulled master and built this afternoon and crashed with "The value 31 is not of type SYMBOL"