### PR TITLE
guix: fix webkitgtk variable name

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -75,7 +75,7 @@
     (inputs
      `(("glib-networking" ,glib-networking)
        ("gsettings-desktop-schemas" ,gsettings-desktop-schemas)
-       ("webkitgtk" ,webkitgtk-2.26)))
+       ("webkitgtk" ,webkitgtk)))
     (native-inputs
      `(("gcc-7" ,gcc-7) ; needed because webkitgtk-2.24+ is compiled with gcc-7
        ("pkg-config" ,pkg-config)))


### PR DESCRIPTION
This change fixes this issue:
  guix environment -l guix.scm
  [...]
  /data/build-scripts/guix.scm:76:5: In procedure inputs:
  error: webkitgtk-2.26: unbound variable

With guix-1.0.1-7.fc1fe72, webkitgtk is 2.26.1.