### PR TITLE
Add new dependency "trivial-types" to guix.scm

### DIFF
--- a/build-scripts/guix.scm
+++ b/build-scripts/guix.scm
@@ -252,6 +252,7 @@ features for productive professionals.")
          ("next-password-manager" ,sbcl-next-password-manager)))
       (native-inputs
        `(("trivial-features" ,sbcl-trivial-features)
+         ("trivial-types" ,sbcl-trivial-types)
          ("prove-asdf" ,sbcl-prove-asdf)))
       (synopsis "Infinitely extensible web-browser (with Lisp development files)"))))
 


### PR DESCRIPTION
A recent commit added "trivial-types" as a new dependency. This must be reflected in `guix.scm`.