### PR TITLE
General-purpose hooks and functional config

### DIFF
--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -851,9 +851,11 @@ to change the style to using upper case, no gradiant, and square boxes:
 
 ** Hooks
 
-A hook is a variable that holds a list of functions.
-We say a hook is executed when all its functions are run one after the other,
-over its arguments (which are decided at the call site).
+A /hook/ holds a list of /handlers/.
+Handlers are specialized functions
+
+Hooks can be /run/, that is, their handlers are run according to the
+=combination= slot of the hook.  This combination is a funtion of the handlers.
 
 Hooks are exposed to the users so that they can customize the behaviour of
 specific actions in arbitrary ways.
@@ -880,7 +882,12 @@ can set a hook like the following in you =~/.config/next/init.lisp=:
         url)))
 
 (defclass my-buffer (buffer)
- ((load-hook :initform (list #'old-reddit-hook))))
+ ((load-hook :initform
+              (make-instance
+               'next-hooks:hook-string->string
+               :handlers (list
+                          (next-hooks:make-handler-string->string #'old-reddit-handler))
+               :combination #'next-hooks:combine-composed-hook))))
 
 (setf *buffer-class* 'my-buffer)
 #+end_src
@@ -896,14 +903,14 @@ for more details.
 All commands  have an associated  "before" and "after" list  of hooks:
 the =help= command has =help-before-hook= and =help-after-hook=.
 
-To add a hook handler, just =push= a function to those lists:
+To add a hook handler, call =add-hook=:
 
 #+begin_src lisp
 (defun hello-hook ()
   (log:info "hello"))
 
-(push #'hello-hook help-before-hook)
-;; (#<FUNCTION HELLO-HOOK>)
+(add-hook help-before-hook
+  (next-hooks:make-handler-void #'hello-hook))
 #+end_src
 
 Now when you press =M-x help=, you'll see
@@ -912,53 +919,53 @@ Now when you press =M-x help=, you'll see
 
 *Initialization and exit* hooks
 
-- =after-init-hook=: hook run after both the lisp side and the
+- =after-init-hook=: Hook run after both the Lisp side and the
 platform port have started.
-  - argument: none
-- =before-exit-hook=: hook run before both the lisp side and the
+  - argument: None.
+- =before-exit-hook=: Hook run before both the Lisp side and the
 platform port get terminated.
-  - argument: none
+  - argument: None.
 
 *Networking* hooks
 
-- =load-hook=: hook  run after the url  to be visited was  parsed. The
-  url isn't loaded yet.
-  - argument: the URL that is going  to be visited.
-  - return: handlers must return a (possibly new) URL (see example above).
+- =load-hook=: Hook  run after the URL  to be visited was  parsed. The
+  URL isn't loaded yet.
+  - argument: The URL that is going  to be visited.
+  - return: Handlers must return a (possibly new) URL (see example above).
 
 *Window* hooks
 
-- =window-make-hook=:  hook run  after the  window is  created on  the
+- =window-make-hook=:  Hook run  after the  window is  created on  the
   platform port.
-  - argument: the window.
-- =window-delete-hook=: hook run before the window is deleted.
-  - argument: the window.
-- =window-set-active-buffer-hook=: hook run before the given buffer is
+  - argument: The window.
+- =window-delete-hook=: Hook run before the window is deleted.
+  - argument: The window.
+- =window-set-active-buffer-hook=: Hook run before the given buffer is
   added to the window and marked the active buffer.
-  - arguments: the window and the buffer.
+  - arguments: The window and the buffer.
 
 *Buffer* hooks
 
-- =buffer-make-hook=:  hook run  after the  buffer is  created on  the
+- =buffer-make-hook=:  Hook run  after the  buffer is  created on  the
   platform port.
-  - argument: the buffer.
-- =buffer-delete-hook=: this hook is run  before the buffer is deleted
+  - argument: The buffer.
+- =buffer-delete-hook=: This hook is run  before the buffer is deleted
   on the platform port.
-  - argument: the buffer object.
+  - argument: The buffer object.
 
 *Download* hooks
 
 - =before-download-hook=: hook run before downloading a URL.
-  - argument: the URL.
-- =after-download-hook=: hook run after a download has completed.
-  - argument: the =download-manager:download= class instance.
+  - argument: The URL.
+- =after-download-hook=: Hook run after a download has completed.
+  - argument: The =download-manager:download= class instance.
 
 *Mode* hooks
 
-- =enable-hook=: this hook is run when enabling the mode.
-  - argument: the mode.
-- =disable-hook=: this hook is run when disabling the mode.
-  - argument: the mode.
+- =enable-hook=: This hook is run when enabling the mode.
+  - argument: The mode.
+- =disable-hook=: This hook is run when disabling the mode.
+  - argument: The mode.
 
 ** Startup behaviour
 

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -208,10 +208,10 @@ To add anonymous functions to HOOK, use
                                   (when (equals f fn)
                                     (setf found-handler f)
                                     t))
-                                handlers)))))
-      (find-handler (handlers hook))
-      (unless found-handler
-        (find-handler (disabled-handlers hook)))
+                                handlers))))
+        (find-handler (handlers hook))
+        (unless found-handler
+          (find-handler (disabled-handlers hook))))
       found-handler)))
 
 (defmethod remove-hook ((hook hook) handler-name)
@@ -223,10 +223,10 @@ To add anonymous functions to HOOK, use
                                   (when (eq handler-name (name f))
                                     (setf found-handler f)
                                     t))
-                                handlers)))))
-      (find-handler (handlers hook))
-      (unless found-handler
-        (find-handler (disabled-handlers hook)))
+                                handlers))))
+        (find-handler (handlers hook))
+        (unless found-handler
+          (find-handler (disabled-handlers hook))))
       found-handler)))
 
 (defmethod run-hook ((hook hook))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -241,8 +241,8 @@ This is an acceptable `combination' for `hook'."
 
 ;; TODO: Because our hooks are typed, having both `run-hook` and
 ;; `run-hook-with-args' makes little sense.  Remove `run-hook-with-args'?
-;; (defmethod run-hook-with-args ((hook hook) &rest args)
-;;   (apply (combination hook) hook args))
+(defmethod run-hook-with-args ((hook hook) &rest args)
+  (apply (combination hook) hook args))
 
 ;; TODO: Implement the following methods? Isn't the `combination' slot more general?
 ;; (defmethod run-hook-with-args-until-failure ((hook hook) &rest args)

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -180,9 +180,13 @@ This is an acceptable `combination' for `hook'."
             (with-hook-restart (apply (fn handler) args)))
           (handlers hook)))
 
-(defmethod combine-hook-until-failure ((hook hook) &rest args) ; TODO: Result difference between "all fail" and "no handlers"?
+(defmethod combine-hook-until-failure ((hook hook) &rest args)
   "Return the list of values until the first nil result.
-Handlers after the successful one are not run.
+Handlers after the failing one are not run.
+
+You need to check if the hook has handlers to know if a NIL return value is due
+to the first handler failing or an empty hook.
+
 This is an acceptable `combination' for `hook'."
   (let ((result nil))
     (loop for handler in (handlers hook)
@@ -191,9 +195,13 @@ This is an acceptable `combination' for `hook'."
           always res)
     (nreverse result)))
 
-(defmethod combine-hook-until-success ((hook hook) &rest args) ; TODO: Result difference between "no success" and "no handlers"?
+(defmethod combine-hook-until-success ((hook hook) &rest args)
   "Return the value of the first non-nil result.
 Handlers after the successful one are not run.
+
+You need to check if the hook has handlers to know if a NIL return value is due
+to all handlers failing or an empty hook.
+
 This is an acceptable `combination' for `hook'."
   (loop for handler in (handlers hook)
      thereis (apply (fn handler) args)))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -1,3 +1,5 @@
+(in-package :next-hooks)
+
 (defvar *hook* nil
   "The hook currently being run.")
 
@@ -5,23 +7,23 @@
   (:documentation "Add FN to the value of HOOK.")
   (:method ((hook symbol) fn &key append)
     (declare (type (or function symbol) fn))
-    (synchronized (hook)
+    (serapeum:synchronized (hook)
       (if (not append)
           (pushnew fn (symbol-value hook))
           (unless (member fn (symbol-value hook))
-            (appendf (symbol-value hook) (list fn)))))))
+            (alexandria:appendf (symbol-value hook) (list fn)))))))
 
 (defgeneric remove-hook (hook fn)
   (:documentation "Remove FN from the symbol value of HOOK.")
   (:method ((hook symbol) fn)
-    (synchronized (hook)
-      (removef (symbol-value hook) fn))))
+    (serapeum:synchronized (hook)
+      (alexandria:removef (symbol-value hook) fn))))
 
 (defmacro with-hook-restart (&body body)
   `(with-simple-restart (continue "Call next function in hook ~s" *hook*)
      ,@body))
 
-(defun run-hooks (&rest hooks)
+(defun run-hooks (&rest hooks)          ; TODO: What about running hooks over arguments?
   "Run all the hooks in HOOKS.
 The variable `*hook*' is bound to the name of each hook as it is being
 run."
@@ -54,3 +56,209 @@ non-nil.")
   (:method ((*hook* symbol) &rest args)
     (loop for fn in (symbol-value *hook*)
             thereis (apply fn args))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(defclass handler ()
+  ((name :initarg :name
+         :accessor name
+         :type symbol
+         :initform nil
+         :documentation "")
+   (description :initarg :description
+                :accessor description
+                :type string
+                :initform ""
+                :documentation "")
+   (fn :initarg :fn
+       :accessor fn
+       :type function
+       :initform nil
+       :documentation "")
+   (place :initarg :place
+          :accessor place
+          :type list
+          :initform nil
+          :documentation "")
+   (value :initarg :value
+          :accessor value
+          :type t
+          :initform nil
+          :documentation "")))
+
+(defun make-handler (function &key name place value)
+  "NAME is a symbol."
+  (setf name (or name (let ((fname (nth-value 2 (function-lambda-expression function))))
+                        (when (typep fname 'symbol)
+                          fname))))
+  (unless name
+    (error "Can't make a handler without a name"))
+  (make-instance 'handler
+                 :name name
+                 :fn function
+                 :place place
+                 :value value))
+
+(defmethod equals ((fn1 handler) (fn2 handler))
+  "Return non-nil if FN1 and FN2 are equal."
+  (cond
+    ((or (and (place fn1)
+              (not (place fn2) ))
+         (and (place fn2)
+              (not (place fn1) )))
+     nil)
+    ((and (place fn1)
+          (place fn2))
+     (and (equal (place fn1)
+                 (place fn2))
+          (equal (value fn1)
+                 (value fn2))))
+    (t
+     (eq (name fn1)
+         (name fn2)))))
+
+(defclass hook ()
+  ((hook-type :initarg :hook-type
+              :accessor hook-type
+              :type symbol
+              :initform t
+              :documentation "
+The type of the handlers, typically (function (input types) output-type).")
+   (handlers :initarg :handlers
+             :accessor handlers
+             :type list
+             :initform '()
+             :documentation "")
+   (disabled-handlers :initarg :disabled-handlers
+                      :accessor disabled-handlers
+                      :type list
+                      :initform '()
+                      :documentation "Those handlers are not run by `run-hook'.
+This is useful it the user wishes to disable some or all handlers without
+removing them from the hook.")
+   (combination :initarg :combination
+                :accessor combination
+                :type function
+                :initform #'default-combine-hook
+                :documentation "
+This can be used to reverse the execution order, return a single value, etc.")))
+
+(defmethod default-combine-hook ((hook hook) &rest args)
+  "Return the list of the results of the HOOK handlers applied from youngest to oldest to ARGS."
+  (mapcar (lambda (handler)
+            (with-hook-restart (apply (fn handler) args)))
+          (handlers hook)))
+
+(defmethod combine-hook-until-failure ((hook hook) &rest args)
+  "Return the list of values until the first nil result.
+Handlers after the successful one are not run."
+  (let ((result nil))
+    (loop for handler in (handlers hook)
+          for res = (apply (fn handler) args)
+          do (push res result)
+          always res)
+    (nreverse result)))
+
+(defmethod combine-hook-until-success ((hook hook) &rest args)
+  "Return the value of the first non-nil result.
+Handlers after the successful one are not run."
+  (loop for handler in (handlers hook)
+          thereis (apply (fn handler) args)))
+
+(defmethod combine-composed-hook ((hook hook) &rest args)
+  "Return the result of the composition of the HOOK handlers on ARGS, from oldest to youngest."
+  (apply (apply #'alexandria:compose (mapcar #'fn (handlers hook))) args))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Compile-time type checking for add-hook is useful in case `add-hook' is not
+;; run when the user config is loaded.  We declaim the type for `add-hook'
+;; because `satisfies' takes the object (the `add-hook' function) as argument,
+;; but we have no way to access the hook or the handler passed as parameter.
+
+(defmethod add-hook ((hook hook) (handler handler) &key append)
+  (serapeum:synchronized (hook)
+    (if (not append)
+        (pushnew handler (handlers hook) :test #'equals)
+        (unless (member handler (handlers hook))
+          (alexandria:appendf (symbol-value hook) (list handler))))))
+
+;; (defmacro add-hook* (hook handler &key append)
+;;   (when (hook-type hook)
+;;     (assert (typep (fn handler) (hook-type hook)) ((fn handler))
+;;             'type-error :datum (fn handler) :expected-type (hook-type hook)))
+;;   `(progn
+;;      (add-hook ,hook ,handler :append ,append)))
+
+(defmethod remove-hook ((hook hook) (fn handler)) ; TODO: Add method to remove handlers by name.
+  (serapeum:synchronized (hook)
+    (let ((found? nil))
+      (setf (handlers hook)
+            (delete-if (lambda (f)
+                         (when (equals f fn)
+                           (setf found? t)
+                           t))
+                       (handlers hook)))
+      (unless found?
+        (delete fn (handlers hook)
+                :test #'equals)))))
+
+(defmethod run-hook ((hook hook))
+  (funcall (combination hook) hook))
+
+;; TODO: Because our hooks are typed, having both `run-hook` and
+;; `run-hook-with-args' makes little sense.  Remove `run-hook-with-args'?
+(defmethod run-hook-with-args ((hook hook) &rest args)
+  (apply (combination hook) hook args))
+
+;; TODO: Implement the following methods? Isn't the `combination' slot more general?
+;; (defmethod run-hook-with-args-until-failure ((hook hook) &rest args)
+;;   (apply (combination hook) hook args))
+;; (defmethod run-hook-with-args-until-success ((hook hook) &rest args)
+;;   (apply (combination hook) hook args))
+
+(defmethod disable-hook ((hook hook) &key append)
+  "Prepend all active handlers to the list of disabled handlers.
+If APPEND is non-nil, append them instead."
+  (serapeum:synchronized (hook)
+    (setf (disabled-handlers hook)
+          (if append
+              (append (disabled-handlers hook) (handlers hook))
+              (append (handlers hook) (disabled-handlers hook))))
+    (setf (handlers hook) nil)))
+
+(defmethod enable-hook ((hook hook) &key append)
+  "Prepend all disabled handlers to the list of active handlers.
+If APPEND is non-nil, append them instead."
+  (serapeum:synchronized (hook)
+    (setf (handlers hook)
+          (if append
+              (append (handlers hook) (disabled-handlers hook))
+              (append (disabled-handlers hook) (handlers hook))))
+    (setf (disabled-handlers hook) nil)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; TODO: cl-hooks uses symbol properties.  Is it a good idea?
+;; TODO: Test this!
+(defvar %hook-table (make-hash-table :test #'equal)
+  "")
+
+(defun define-hook (name &key object type handlers disabled-handlers combination)
+  "Create a globally accessible hook."
+  (let ((hook
+          (make-instance 'hook
+                         :type type
+                         :handlers handlers
+                         :disabled-handlers disabled-handlers
+                         :combination combination)))
+    (setf (gethash (list name object) %hook-table)
+          hook)))
+
+(defun find-hook (name &optional object)
+  "Return the global hook with name NAME associated to OBJECT, if provided.
+The following examples return different hooks:
+- (find-hook 'foo-hook)
+- (find-hook 'foo-hook 'bar-class)
+- (find-hook 'foo-hook (make-instance 'bar-class))"
+  (gethash (list name object) %hook-table))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -278,7 +278,6 @@ If APPEND is non-nil, append them instead."
 ;; Global hooks.
 
 ;; TODO: cl-hooks uses symbol properties.  Is it a good idea?
-;; TODO: Test this!
 (defvar %hook-table (make-hash-table :test #'equal)
   "Global hook table.")
 

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -236,6 +236,8 @@ This is an acceptable `combination' for `hook'."
           (find-handler (disabled-handlers hook))))
       found-handler)))
 
+;; TODO: What do we return when hook has no handler?  How do we distinguish
+;; between a NIL return value and no handler?
 (defmethod run-hook ((hook hook))
   (funcall (combination hook) hook))
 
@@ -269,6 +271,8 @@ If APPEND is non-nil, append them instead."
               (append (handlers hook) (disabled-handlers hook))
               (append (disabled-handlers hook) (handlers hook))))
     (setf (disabled-handlers hook) nil)))
+
+;; TODO: Add `disable-handler' and `enable-handler'?  Or simply add `handlers' argument to disable-hook / enable-hook?
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Global hooks.

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -279,11 +279,15 @@ Return HOOK's handlers."
 (defmethod run-hook ((hook hook) &rest args)
   (apply (combination hook) hook args))
 
-;; TODO: Implement the following methods? Isn't the `combination' slot more general?
-;; (defmethod run-hook-with-args-until-failure ((hook hook) &rest args)
-;;   (apply (combination hook) hook args))
-;; (defmethod run-hook-with-args-until-success ((hook hook) &rest args)
-;;   (apply (combination hook) hook args))
+(defmethod run-hook-with-args-until-failure ((hook hook) &rest args)
+  "This is equivalent to setting the combination function to
+`combine-hook-until-failure' and calling `run-hook'."
+  (apply #'combine-hook-until-failure hook args))
+
+(defmethod run-hook-with-args-until-success ((hook hook) &rest args)
+  "This is equivalent to setting the combination function to
+`combine-hook-until-success' and calling `run-hook'."
+  (apply #'combine-hook-until-success hook args))
 
 (defun move-hook-handlers (hook source-handlers-slot destination-handlers-slot select-handlers)
   (serapeum:synchronized (hook)

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -342,6 +342,7 @@ HANDLER must be of type ~a."
          (add-hook-internal hook handler :append append)))))
 
 ;; TODO: Add make-hook-* function?
+;; TODO: Allow listing all the hooks?
 
 (define-hook-type void (function ()))
 (define-hook-type string->string (function (string) string))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -1,0 +1,56 @@
+(defvar *hook* nil
+  "The hook currently being run.")
+
+(defgeneric add-hook (hook fn &key append)
+  (:documentation "Add FN to the value of HOOK.")
+  (:method ((hook symbol) fn &key append)
+    (declare (type (or function symbol) fn))
+    (synchronized (hook)
+      (if (not append)
+          (pushnew fn (symbol-value hook))
+          (unless (member fn (symbol-value hook))
+            (appendf (symbol-value hook) (list fn)))))))
+
+(defgeneric remove-hook (hook fn)
+  (:documentation "Remove FN from the symbol value of HOOK.")
+  (:method ((hook symbol) fn)
+    (synchronized (hook)
+      (removef (symbol-value hook) fn))))
+
+(defmacro with-hook-restart (&body body)
+  `(with-simple-restart (continue "Call next function in hook ~s" *hook*)
+     ,@body))
+
+(defun run-hooks (&rest hooks)
+  "Run all the hooks in HOOKS.
+The variable `*hook*' is bound to the name of each hook as it is being
+run."
+  (dolist (*hook* hooks)
+    (run-hook *hook*)))
+
+(defgeneric run-hook (hook)
+  (:documentation "Run the functions in HOOK.")
+  (:method ((*hook* symbol))
+    (dolist (fn (symbol-value *hook*))
+      (with-hook-restart
+        (funcall fn)))))
+
+(defgeneric run-hook-with-args (hook &rest args)
+  (:documentation "Apply each function in HOOK to ARGS.")
+  (:method ((*hook* symbol) &rest args)
+    (dolist (fn (symbol-value *hook*))
+      (with-hook-restart
+        (apply fn args)))))
+
+(defgeneric run-hook-with-args-until-failure (hook &rest args)
+  (:documentation "Like `run-hook-with-args', but quit once a function returns nil.")
+  (:method ((*hook* symbol) &rest args)
+    (loop for fn in (symbol-value *hook*)
+          always (apply fn args))))
+
+(defgeneric run-hook-with-args-until-success (hook &rest args)
+  (:documentation "Like `run-hook-with-args', but quit once a function returns
+non-nil.")
+  (:method ((*hook* symbol) &rest args)
+    (loop for fn in (symbol-value *hook*)
+            thereis (apply fn args))))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -199,18 +199,35 @@ To add anonymous functions to HOOK, use
 ;;   `(progn
 ;;      (add-hook ,hook ,handler :append ,append)))
 
-(defmethod remove-hook ((hook hook) (fn handler)) ; TODO: Add method to remove handlers by name.
+(defmethod remove-hook ((hook hook) (fn handler))
   (serapeum:synchronized (hook)
-    (let ((found? nil))
-      (setf (handlers hook)
-            (delete-if (lambda (f)
-                         (when (equals f fn)
-                           (setf found? t)
-                           t))
-                       (handlers hook)))
-      (unless found?
-        (delete fn (handlers hook)
-                :test #'equals)))))
+    (let ((found-handler nil))
+      (flet ((find-handler (handlers)
+               (setf (handlers hook)
+                     (delete-if (lambda (f)
+                                  (when (equals f fn)
+                                    (setf found-handler f)
+                                    t))
+                                handlers)))))
+      (find-handler (handlers hook))
+      (unless found-handler
+        (find-handler (disabled-handlers hook)))
+      found-handler)))
+
+(defmethod remove-hook ((hook hook) handler-name)
+  (serapeum:synchronized (hook)
+    (let ((found-handler nil))
+      (flet ((find-handler (handlers)
+               (setf (handlers hook)
+                     (delete-if (lambda (f)
+                                  (when (eq handler-name (name f))
+                                    (setf found-handler f)
+                                    t))
+                                handlers)))))
+      (find-handler (handlers hook))
+      (unless found-handler
+        (find-handler (disabled-handlers hook)))
+      found-handler)))
 
 (defmethod run-hook ((hook hook))
   (funcall (combination hook) hook))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -87,6 +87,8 @@ non-nil.")
           :initform nil
           :documentation "")))
 
+;; TODO: Don't export make-handler, so that user is forced to use the typed versions.
+;; But then how does the user define a custom-type handler?
 (defun make-handler (fn &key name place value)
   "NAME is a symbol."
   (unless (typep fn 'function)          ; TODO: Should we allow symbols here?  It might be better to be stricter in terms of type-checking.
@@ -101,6 +103,27 @@ non-nil.")
                  :fn fn
                  :place place
                  :value value))
+
+
+(declaim (ftype (function ((function ()) &key (:name symbol) (:place t) (:value t))) make-void-handler))
+(defun make-void-handler (fn &key name place value)
+  "Make handler that accepts no argument."
+  (make-handler fn :name name :place place :value value))
+
+(declaim (ftype (function ((function (&rest t)) &key (:name symbol) (:place t) (:value t))) make-*-handler))
+(defun make-*-handler (fn &key name place value)
+  "Make handler that accepts any argument."
+  (make-handler fn :name name :place place :value value))
+
+(declaim (ftype (function ((function (number) number) &key (:name symbol) (:place t) (:value t)))
+                make-number->number-handler))
+(defun make-number->number-handler (fn &key name place value)
+  (make-handler fn :name name :place place :value value))
+
+(declaim (ftype (function ((function (string) string) &key (:name symbol) (:place t) (:value t)))
+                make-string->string-handler))
+(defun make-string->string-handler (fn &key name place value)
+  (make-handler fn :name name :place place :value value))
 
 (defmethod equals ((fn1 handler) (fn2 handler))
   "Return non-nil if FN1 and FN2 are equal."

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -183,6 +183,15 @@ Handlers after the successful one are not run."
         (unless (member handler (handlers hook))
           (alexandria:appendf (symbol-value hook) (list handler))))))
 
+(defmethod add-hook ((hook hook) fn &key append)
+  "Add FN to HOOK.
+FN cannot be an anonymous function.
+To add anonymous functions to HOOK, use
+
+  (add-hook hook (make-handler (lambda () ...) :name ...))"
+  (let ((handler (make-handler fn)))
+    (add-hook hook handler :append append)))
+
 ;; (defmacro add-hook* (hook handler &key append)
 ;;   (when (hook-type hook)
 ;;     (assert (typep (fn handler) (hook-type hook)) ((fn handler))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -96,12 +96,24 @@ This can be left empty if the handler is not a setter.")
 If the handler is meant to be a setter, VALUE can be used to describe what FN is
 going to set to PLACE.
 In particular, PLACE and VALUE can be used to compare handlers.
-This can be left empty if the handler is not a setter.")))
+This can be left empty if the handler is not a setter."))
+  (:documentation "Handlers are wrappers around functions used in typed hooks.
+They serve two purposes as opposed to regular functions:
 
-;; TODO: Maybe don't export make-handler, so that user is forced to use the
-;; typed versions.
+- They can embed a NAME so that anonymous functions can be conveniently used in lambda.
+- If the handler is meant to be a setter, the PLACE and VALUE slot can be used to identify and compare setters.
+
+With this extra information, it's possible to compare handlers and, in particular, avoid duplicates in hooks."))
+
 (defun make-handler (fn &key (class-name 'handler) name handler-type place value)
-  "NAME is a symbol."
+  "Return a `handler'.
+NAME is only mandatory if FN is a lambda.
+CLASS-NAME can be used to create handler subclasses.
+
+HANDLER-TYPE, PLACE and VALUE are as per the sltos in `handler-type'.
+
+This function should not be used directly.
+Prefer the typed make-handler-* functions instead."
   (setf name (or name (let ((fname (nth-value 2 (function-lambda-expression fn))))
                         (when (typep fname 'symbol)
                           fname))))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -220,6 +220,14 @@ If APPEND is non-nil, HANDLER is added at the end."
           (alexandria:appendf (symbol-value hook) (list handler))
           (pushnew handler (handlers hook) :test #'equals)))))
 
+(declaim (ftype (function ((or handler symbol) list) (or handler boolean)) find-handler))
+(defun find-handler (handler-or-name handlers)
+  "Return handler matching HANDLER-OR-NAME in HANDLERS sequence."
+  (apply #'find handler-or-name handlers
+         (if (typep handler-or-name 'handler)
+             (list :test #'equals)
+             (list :key #'name))))
+
 (defmethod remove-hook ((hook hook) (fn handler))
   (serapeum:synchronized (hook)
     (let ((found-handler nil))

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -266,17 +266,19 @@ If APPEND is non-nil, append them instead."
 ;; TODO: cl-hooks uses symbol properties.  Is it a good idea?
 ;; TODO: Test this!
 (defvar %hook-table (make-hash-table :test #'equal)
-  "")
+  "Global hook table.")
 
-(defun define-hook (name &key object handlers disabled-handlers combination)
-  "Create a globally accessible hook."
+(defun define-hook (hook-type name &key object handlers disabled-handlers combination)
+  "Return a globally-accessible hook.
+The hook can be accessed with `find-hook'."
   (let ((hook
-          (make-instance 'hook          ; TODO: Handler class?
+          (make-instance hook-type
                          :handlers handlers
                          :disabled-handlers disabled-handlers
                          :combination combination)))
     (setf (gethash (list name object) %hook-table)
-          hook)))
+          hook)
+    hook))
 
 (defun find-hook (name &optional object)
   "Return the global hook with name NAME associated to OBJECT, if provided.

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -169,7 +169,16 @@ removing them from the hook.")
                 :type function
                 :initform #'default-combine-hook
                 :documentation "
-This can be used to reverse the execution order, return a single value, etc.")))
+This can be used to reverse the execution order, return a single value, etc."))
+  (:documentation "This hook class serves as support for typed-hook.
+
+Typing in hook is crucial to guarantee that a hook is well formed, i.e. that
+it's handlers accept the right argument types and return the right value types.
+
+Because typing is too limited in Common Lisp, we leverage CLOS to generate
+subclasses of `hook' and `handlers' with typed helper functions.
+The `add-hook' will thus only accept handlers of the right types.
+This implementation is good enough to catch typing errors at compile time."))
 
 (defmethod default-combine-hook ((hook hook) &rest args)
   "Return the list of the results of the HOOK handlers applied from youngest to

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -87,16 +87,18 @@ non-nil.")
           :initform nil
           :documentation "")))
 
-(defun make-handler (function &key name place value)
+(defun make-handler (fn &key name place value)
   "NAME is a symbol."
-  (setf name (or name (let ((fname (nth-value 2 (function-lambda-expression function))))
+  (unless (typep fn 'function)          ; TODO: Should we allow symbols here?  It might be better to be stricter in terms of type-checking.
+    (setf fn (function fn)))
+  (setf name (or name (let ((fname (nth-value 2 (function-lambda-expression fn))))
                         (when (typep fname 'symbol)
                           fname))))
   (unless name
     (error "Can't make a handler without a name"))
   (make-instance 'handler
                  :name name
-                 :fn function
+                 :fn fn
                  :place place
                  :value value))
 

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -23,21 +23,14 @@
   `(with-simple-restart (continue "Call next function in hook ~s" *hook*)
      ,@body))
 
-(defun run-hooks (&rest hooks)          ; TODO: What about running hooks over arguments?
-  "Run all the hooks in HOOKS.
+(defun run-hooks (&rest hooks)
+  "Run all the hooks in HOOKS, without arguments.
 The variable `*hook*' is bound to the name of each hook as it is being
 run."
   (dolist (*hook* hooks)
     (run-hook *hook*)))
 
-(defgeneric run-hook (hook)
-  (:documentation "Run the functions in HOOK.")
-  (:method ((*hook* symbol))
-    (dolist (fn (symbol-value *hook*))
-      (with-hook-restart
-        (funcall fn)))))
-
-(defgeneric run-hook-with-args (hook &rest args)
+(defgeneric run-hook (hook &rest args)
   (:documentation "Apply each function in HOOK to ARGS.")
   (:method ((*hook* symbol) &rest args)
     (dolist (fn (symbol-value *hook*))
@@ -241,12 +234,7 @@ This is an acceptable `combination' for `hook'."
           (find-handler (disabled-handlers hook))))
       found-handler)))
 
-(defmethod run-hook ((hook hook))
-  (funcall (combination hook) hook))
-
-;; TODO: Because our hooks are typed, having both `run-hook` and
-;; `run-hook-with-args' makes little sense.  Remove `run-hook-with-args'?
-(defmethod run-hook-with-args ((hook hook) &rest args)
+(defmethod run-hook ((hook hook) &rest args)
   (apply (combination hook) hook args))
 
 ;; TODO: Implement the following methods? Isn't the `combination' slot more general?

--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -210,11 +210,15 @@ This is an acceptable `combination' for `hook'."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun add-hook-internal (hook handler &key append)
+  "Add HANDLER to HOOK if not already in it.
+HANDLER is also not added if in the `disabled-handlers'.
+If APPEND is non-nil, HANDLER is added at the end."
   (serapeum:synchronized (hook)
-    (if (not append)
-        (pushnew handler (handlers hook) :test #'equals)
-        (unless (member handler (handlers hook))
-          (alexandria:appendf (symbol-value hook) (list handler))))))
+    (unless (or (member handler (handlers hook) :test #'equals)
+                (member handler (disabled-handlers hook) :test #'equals))
+      (if append
+          (alexandria:appendf (symbol-value hook) (list handler))
+          (pushnew handler (handlers hook) :test #'equals)))))
 
 (defmethod remove-hook ((hook hook) (fn handler))
   (serapeum:synchronized (hook)

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -8,11 +8,9 @@
    #:remove-hook
    #:run-hooks
    #:run-hook
-   #:run-hook-with-args
    #:run-hook-with-args-until-failure
    #:run-hook-with-args-until-success
    ;; #:make-handler ; Leave unexported to incite using typed handlers.
-   #:equals
    #:default-combine-hook
    #:combine-hook-until-failure
    #:combine-hook-until-success

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -15,7 +15,7 @@
    #:combine-hook-until-failure
    #:combine-hook-until-success
    #:combine-composed-hook
-   #:remove-hook
+   #:find-handler
    #:disable-hook
    #:enable-hook
    #:define-hook

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -11,7 +11,7 @@
    #:run-hook-with-args
    #:run-hook-with-args-until-failure
    #:run-hook-with-args-until-success
-   #:make-handler
+   ;; #:make-handler ; Leave unexported to incite using typed handlers.
    #:equals
    #:default-combine-hook
    #:combine-hook-until-failure

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -1,4 +1,40 @@
 (in-package :cl-user)
 
 (defpackage :next-hooks
-  (:use :common-lisp))
+  (:use :common-lisp)
+  (:export
+   #:*hook*
+   #:add-hook
+   #:remove-hook
+   #:run-hooks
+   #:run-hook
+   #:run-hook-with-args
+   #:run-hook-with-args-until-failure
+   #:run-hook-with-args-until-success
+   #:handler
+   #:name
+   #:description
+   #:handler-type
+   #:place
+   #:value
+   #:make-handler
+   #:equals
+   #:hook
+   #:default-combine-hook
+   #:combine-hook-until-failure
+   #:combine-hook-until-success
+   #:combine-composed-hook
+   #:remove-hook
+   #:disable-hook
+   #:enable-hook
+   #:define-hook
+   #:find-hook
+   #:define-hook-type
+   ;; Pre-generated types
+   ;; TODO: Add the rest.
+   #:make-handler-string->string
+   #:handler-string->string
+   #:hook-string->string
+   #:make-handler-void
+   #:handler-void
+   #:hook-void))

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -11,15 +11,8 @@
    #:run-hook-with-args
    #:run-hook-with-args-until-failure
    #:run-hook-with-args-until-success
-   #:handler
-   #:name
-   #:description
-   #:handler-type
-   #:place
-   #:value
    #:make-handler
    #:equals
-   #:hook
    #:default-combine-hook
    #:combine-hook-until-failure
    #:combine-hook-until-success
@@ -30,11 +23,28 @@
    #:define-hook
    #:find-hook
    #:define-hook-type
-   ;; Pre-generated types
-   ;; TODO: Add the rest.
+   ;; Handler class:
+   #:handler
+   #:name
+   #:description
+   #:handler-type
+   #:place
+   #:value
+   ;; Hook class:
+   #:hook
+   #:handlers
+   #:disabled-handlers
+   #:combination
+   ;; Pre-generated types:
+   #:make-handler-void
+   #:handler-void
+   #:hook-void
    #:make-handler-string->string
    #:handler-string->string
    #:hook-string->string
-   #:make-handler-void
-   #:handler-void
-   #:hook-void))
+   #:make-handler-number->number
+   #:handler-number->number
+   #:hook-number->number
+   #:make-handler-any
+   #:handler-any
+   #:hook-any))

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -37,12 +37,16 @@
    #:make-handler-void
    #:handler-void
    #:hook-void
+   #:make-hook-void
    #:make-handler-string->string
    #:handler-string->string
    #:hook-string->string
+   #:make-hook-string->string
    #:make-handler-number->number
    #:handler-number->number
    #:hook-number->number
+   #:make-hook-number->number
    #:make-handler-any
    #:handler-any
-   #:hook-any))
+   #:hook-any
+   #:make-hook-any))

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -1,0 +1,4 @@
+(in-package :cl-user)
+
+(defpackage :next-hooks
+  (:use :common-lisp))

--- a/libraries/hooks/readme.org
+++ b/libraries/hooks/readme.org
@@ -19,6 +19,7 @@ What we need from hooks:
   - (find-hook 'foo-hook)
   - (find-hook 'foo-hook 'bar-class)
   - (find-hook 'foo-hook (make-instance 'bar-class))
+- Adding the same hook twice should be a no-op.
 
 
 Links:

--- a/libraries/hooks/readme.org
+++ b/libraries/hooks/readme.org
@@ -1,7 +1,7 @@
 What we need from hooks:
 
 - Be able to tell what is a hook, so it must be a class.
-- The user should be able to easily enabled/disabled hooks, without modifying
+- The user should be able to easily enable/disable hooks, without modifying
   the handler list.
   What about enabling / disabling handlers individually?  It's more general, a hook could
   have 2 lists, one of enabled handlers, the other of disabled handlers.  A
@@ -9,7 +9,7 @@ What we need from hooks:
 - List all the hooks.
 - Make closures more usable as handlers.  We need a handler type that can name
   the closure.
-- Handlers can take parameters can return values.  Hook should be typed accordingly.
+- Handlers can take parameters and can return values.  Hook should be typed accordingly.
 - The handler composition can be customized, e.g. we could set a function to
   tell what to do with it, one of `reduce`, `list`, etc.
   This can be used to customize the order in which the handlers are run

--- a/libraries/hooks/readme.org
+++ b/libraries/hooks/readme.org
@@ -1,0 +1,28 @@
+What we need from hooks:
+
+- Be able to tell what is a hook, so it must be a class.
+- The user should be able to easily enabled/disabled hooks, without modifying
+  the handler list.
+  What about enabling / disabling handlers individually?  It's more general, a hook could
+  have 2 lists, one of enabled handlers, the other of disabled handlers.  A
+  method can enable  / disable all handlers at once.
+- List all the hooks.
+- Make closures more usable as handlers.  We need a handler type that can name
+  the closure.
+- Handlers can take parameters can return values.  Hook should be typed accordingly.
+- The handler composition can be customized, e.g. we could set a function to
+  tell what to do with it, one of `reduce`, `list`, etc.
+  This can be used to customize the order in which the handlers are run
+  (e.g. LIFO / FIFO).
+- Allow the definition of global hooks that can be associated with an object.
+  We could use a hash table.
+  - (find-hook 'foo-hook)
+  - (find-hook 'foo-hook 'bar-class)
+  - (find-hook 'foo-hook (make-instance 'bar-class))
+
+
+Links:
+- https://github.com/ruricolist/serapeum/issues/41
+- https://github.com/atlas-engineer/next/issues/419
+- https://github.com/scymtym/architecture.hooks/issues/2
+- https://github.com/scymtym/architecture.hooks/issues/3

--- a/libraries/hooks/tests/tests.lisp
+++ b/libraries/hooks/tests/tests.lisp
@@ -23,14 +23,14 @@
   (* 2 n))
 
 (prove:subtest "Run default numeric hook"
-  (prove:is (next-hooks:run-hook-with-args
+  (prove:is (next-hooks:run-hook
              (make-instance 'next-hooks:hook-number->number
                             :handlers (list (next-hooks:make-handler-number->number #'add1)))
              17)
             '(18)))
 
 (prove:subtest "Run default numeric hook with multiple handlers"
-  (prove:is (next-hooks:run-hook-with-args
+  (prove:is (next-hooks:run-hook
              (make-instance 'next-hooks:hook-number->number
                             :handlers (list (next-hooks:make-handler-number->number #'add1)
                                             (next-hooks:make-handler-number->number
@@ -44,13 +44,13 @@
                         (make-instance 'next-hooks:hook-number->number
                                        :handlers (list (next-hooks:make-handler-number->number #'add1)))))
               (next-hooks:add-hook hook (next-hooks:make-handler-number->number #'add1))
-              (next-hooks:run-hook-with-args hook 17))
+              (next-hooks:run-hook hook 17))
             '(18))
   (prove:is (let ((hook
                         (make-instance 'next-hooks:hook-number->number
                                        :handlers (list (next-hooks:make-handler-number->number #'add1)))))
               (next-hooks:add-hook hook (next-hooks:make-handler-number->number (lambda (n) (+ 1 n)) :name 'add1))
-              (next-hooks:run-hook-with-args hook 17))
+              (next-hooks:run-hook hook 17))
             '(18)))
 
 (prove:subtest "Combine handlers"
@@ -59,12 +59,12 @@
                                        :handlers (list (next-hooks:make-handler-number->number #'add1)
                                                        (next-hooks:make-handler-number->number #'mul2))
                                        :combination #'next-hooks:combine-composed-hook)))
-              (next-hooks:run-hook-with-args hook 17))
+              (next-hooks:run-hook hook 17))
             35)
   (prove:is (let ((hook
                         (make-instance 'next-hooks:hook-number->number
                                        :combination #'next-hooks:combine-composed-hook)))
-              (next-hooks:run-hook-with-args hook 17))
+              (next-hooks:run-hook hook 17))
             17))
 
 (prove:subtest "Remove handler from hook"
@@ -75,7 +75,7 @@
                                                     (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
               (next-hooks:remove-hook hook 'mul3)
               (next-hooks:remove-hook hook handler1)
-              (next-hooks:run-hook-with-args hook 17))
+              (next-hooks:run-hook hook 17))
             nil))
 
 (prove:subtest "Disable hook"

--- a/libraries/hooks/tests/tests.lisp
+++ b/libraries/hooks/tests/tests.lisp
@@ -60,7 +60,12 @@
                                                        (next-hooks:make-handler-number->number #'mul2))
                                        :combination #'next-hooks:combine-composed-hook)))
               (next-hooks:run-hook-with-args hook 17))
-            35))
+            35)
+  (prove:is (let ((hook
+                        (make-instance 'next-hooks:hook-number->number
+                                       :combination #'next-hooks:combine-composed-hook)))
+              (next-hooks:run-hook-with-args hook 17))
+            17))
 
 (prove:subtest "Remove handler from hook"
   (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))

--- a/libraries/hooks/tests/tests.lisp
+++ b/libraries/hooks/tests/tests.lisp
@@ -1,0 +1,140 @@
+(in-package :cl-user)
+
+(prove:plan nil)
+
+(defun void-function ()
+  (format t "Void handler"))
+
+(defvar test-hook (make-instance 'next-hooks:hook-void))
+(next-hooks:add-hook test-hook
+                     (next-hooks:make-handler-void #'void-function))
+
+(prove:subtest "Run default void hook"
+  (prove:is (length (next-hooks:handlers test-hook))
+            1)
+  (prove:is (next-hooks:run-hook test-hook)
+            '(nil)))
+
+(defun add1 (n)
+  (1+ n))
+
+(declaim (ftype (function (number) number) mul2))
+(defun mul2 (n)
+  (* 2 n))
+
+(prove:subtest "Run default numeric hook"
+  (prove:is (next-hooks:run-hook-with-args
+             (make-instance 'next-hooks:hook-number->number
+                            :handlers (list (next-hooks:make-handler-number->number #'add1)))
+             17)
+            '(18)))
+
+(prove:subtest "Run default numeric hook with multiple handlers"
+  (prove:is (next-hooks:run-hook-with-args
+             (make-instance 'next-hooks:hook-number->number
+                            :handlers (list (next-hooks:make-handler-number->number #'add1)
+                                            (next-hooks:make-handler-number->number
+                                             (lambda (n) (* 2 n))
+                                             :name 'mul2)))
+             17)
+            '(18 34)))
+
+(prove:subtest "Don't add duplicate handlers."
+  (prove:is (let ((hook
+                        (make-instance 'next-hooks:hook-number->number
+                                       :handlers (list (next-hooks:make-handler-number->number #'add1)))))
+              (next-hooks:add-hook hook (next-hooks:make-handler-number->number #'add1))
+              (next-hooks:run-hook-with-args hook 17))
+            '(18))
+  (prove:is (let ((hook
+                        (make-instance 'next-hooks:hook-number->number
+                                       :handlers (list (next-hooks:make-handler-number->number #'add1)))))
+              (next-hooks:add-hook hook (next-hooks:make-handler-number->number (lambda (n) (+ 1 n)) :name 'add1))
+              (next-hooks:run-hook-with-args hook 17))
+            '(18)))
+
+(prove:subtest "Combine handlers"
+  (prove:is (let ((hook
+                        (make-instance 'next-hooks:hook-number->number
+                                       :handlers (list (next-hooks:make-handler-number->number #'add1)
+                                                       (next-hooks:make-handler-number->number #'mul2))
+                                       :combination #'next-hooks:combine-composed-hook)))
+              (next-hooks:run-hook-with-args hook 17))
+            35))
+
+(prove:subtest "Remove handler from hook"
+  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
+                   (hook
+                     (make-instance 'next-hooks:hook-number->number
+                                    :handlers (list handler1
+                                                    (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+              (next-hooks:remove-hook hook 'mul3)
+              (next-hooks:remove-hook hook handler1)
+              (next-hooks:run-hook-with-args hook 17))
+            nil))
+
+(prove:subtest "Disable hook"
+  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
+                   (hook
+                     (make-instance 'next-hooks:hook-number->number
+                                    :handlers (list handler1
+                                                    (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+              (next-hooks:disable-hook hook)
+              (length (next-hooks:disabled-handlers hook)))
+            2)
+  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
+                   (hook
+                     (make-instance 'next-hooks:hook-number->number
+                                    :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+              (next-hooks:disable-hook hook)
+              (next-hooks:add-hook hook handler1)
+              (next-hooks:disable-hook hook :append t)
+              (eq (second (next-hooks:disabled-handlers hook))
+                  handler1))
+            t)
+  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
+                   (hook
+                     (make-instance 'next-hooks:hook-number->number
+                                    :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+              (next-hooks:disable-hook hook)
+              (next-hooks:add-hook hook handler1)
+              (next-hooks:disable-hook hook)
+              (eq (first (next-hooks:disabled-handlers hook))
+                  handler1))
+            t)
+  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
+                   (hook
+                     (make-instance 'next-hooks:hook-number->number
+                                    :handlers (list handler1
+                                                    (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+              (next-hooks:disable-hook hook)
+              (next-hooks:enable-hook hook)
+              (length (next-hooks:disabled-handlers hook)))
+            0))
+
+(prove:subtest "Don't accept lambdas without names."
+  (prove:is-error (next-hooks:make-handler-number->number (lambda (n) (+ 1 n)))
+                  'simple-error))
+
+(prove:subtest "Global hooks"
+  (prove:is (let ((hook (next-hooks:define-hook 'next-hooks:hook-number->number 'foo)))
+              (eq hook (next-hooks:find-hook 'foo)))
+            t)
+  (let ((hook (next-hooks:define-hook 'next-hooks:hook-number->number 'foo)))
+    (prove:is (next-hooks:find-hook 'foo)
+              hook))
+  (let ((hook (next-hooks:define-hook 'next-hooks:hook-number->number 'foo
+                :object #'mul2)))
+    (prove:isnt (next-hooks:find-hook 'foo)
+                hook))
+  (let ((hook (next-hooks:define-hook 'next-hooks:hook-number->number 'foo
+                :object #'mul2)))
+    (prove:is (next-hooks:find-hook 'foo #'mul2)
+              hook)))
+
+;; TODO: Test that make-handler-* raise a warning when passed a function with the wrong type.
+;; Example: (next-hooks:make-handler-string->string #'mul2)
+
+;; TODO: Test that functions can be redefined.
+
+(prove:finalize)

--- a/libraries/hooks/tests/tests.lisp
+++ b/libraries/hooks/tests/tests.lisp
@@ -137,6 +137,18 @@
     (prove:is (next-hooks:find-hook 'foo #'mul2)
               hook)))
 
+(prove:subtest "Find handler"
+  (let* ((add-handler (next-hooks:make-handler-number->number #'add1))
+         (mul-handler (next-hooks:make-handler-number->number #'mul2))
+         (other-handler (next-hooks:make-handler-void #'void-function))
+         (handlers (list add-handler mul-handler)))
+    (prove:is (next-hooks:find-handler 'add1 handlers)
+              add-handler)
+    (prove:is (next-hooks:find-handler mul-handler handlers)
+              mul-handler)
+    (prove:is (next-hooks:find-handler other-handler handlers)
+              nil)))
+
 ;; TODO: Test that make-handler-* raise a warning when passed a function with the wrong type.
 ;; Example: (next-hooks:make-handler-string->string #'mul2)
 

--- a/libraries/hooks/tests/tests.lisp
+++ b/libraries/hooks/tests/tests.lisp
@@ -79,43 +79,38 @@
             nil))
 
 (prove:subtest "Disable hook"
-  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
-                   (hook
-                     (make-instance 'next-hooks:hook-number->number
-                                    :handlers (list handler1
-                                                    (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
-              (next-hooks:disable-hook hook)
-              (length (next-hooks:disabled-handlers hook)))
-            2)
-  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
-                   (hook
-                     (make-instance 'next-hooks:hook-number->number
-                                    :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
-              (next-hooks:disable-hook hook)
-              (next-hooks:add-hook hook handler1)
-              (next-hooks:disable-hook hook :append t)
-              (eq (second (next-hooks:disabled-handlers hook))
-                  handler1))
-            t)
-  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
-                   (hook
-                     (make-instance 'next-hooks:hook-number->number
-                                    :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
-              (next-hooks:disable-hook hook)
-              (next-hooks:add-hook hook handler1)
-              (next-hooks:disable-hook hook)
-              (eq (first (next-hooks:disabled-handlers hook))
-                  handler1))
-            t)
-  (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
-                   (hook
-                     (make-instance 'next-hooks:hook-number->number
-                                    :handlers (list handler1
-                                                    (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
-              (next-hooks:disable-hook hook)
-              (next-hooks:enable-hook hook)
-              (length (next-hooks:disabled-handlers hook)))
-            0))
+  (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
+         (handler2 (next-hooks:make-handler-number->number #'mul2)))
+    (prove:is (let* ((hook (make-instance 'next-hooks:hook-number->number
+                                          :handlers (list handler1
+                                                          (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+                (next-hooks:disable-hook hook)
+                (length (next-hooks:disabled-handlers hook)))
+              2)
+    (prove:is (let* ((hook
+                       (make-instance 'next-hooks:hook-number->number
+                                      :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+                (next-hooks:disable-hook hook)
+                (next-hooks:add-hook hook handler1)
+                (next-hooks:disable-hook hook)
+                (eq (first (next-hooks:disabled-handlers hook))
+                    handler1))
+              t)
+    (prove:is (let* ((hook
+                       (make-instance 'next-hooks:hook-number->number
+                                      :handlers (list handler1
+                                                      (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+                (next-hooks:disable-hook hook)
+                (next-hooks:enable-hook hook)
+                (length (next-hooks:disabled-handlers hook)))
+              0)
+    (prove:is (let* ((hook
+                       (make-instance 'next-hooks:hook-number->number
+                                      :handlers (list handler1 handler2))))
+                (next-hooks:disable-hook hook handler1)
+                (list (first (next-hooks:handlers hook))
+                      (first (next-hooks:disabled-handlers hook))))
+              (list handler2 handler1))))
 
 (prove:subtest "Don't accept lambdas without names."
   (prove:is-error (next-hooks:make-handler-number->number (lambda (n) (+ 1 n)))

--- a/libraries/hooks/tests/tests.lisp
+++ b/libraries/hooks/tests/tests.lisp
@@ -5,7 +5,7 @@
 (defun void-function ()
   (format t "Void handler"))
 
-(defvar test-hook (make-instance 'next-hooks:hook-void))
+(defvar test-hook (next-hooks:make-hook-void))
 (next-hooks:add-hook test-hook
                      (next-hooks:make-handler-void #'void-function))
 
@@ -24,15 +24,14 @@
 
 (prove:subtest "Run default numeric hook"
   (prove:is (next-hooks:run-hook
-             (make-instance 'next-hooks:hook-number->number
-                            :handlers (list (next-hooks:make-handler-number->number #'add1)))
+             (next-hooks:make-hook-number->number :handlers (list #'add1))
              17)
             '(18)))
 
 (prove:subtest "Run default numeric hook with multiple handlers"
   (prove:is (next-hooks:run-hook
-             (make-instance 'next-hooks:hook-number->number
-                            :handlers (list (next-hooks:make-handler-number->number #'add1)
+             (next-hooks:make-hook-number->number
+                            :handlers (list #'add1
                                             (next-hooks:make-handler-number->number
                                              (lambda (n) (* 2 n))
                                              :name 'mul2)))
@@ -40,39 +39,31 @@
             '(18 34)))
 
 (prove:subtest "Don't add duplicate handlers."
-  (prove:is (let ((hook
-                        (make-instance 'next-hooks:hook-number->number
-                                       :handlers (list (next-hooks:make-handler-number->number #'add1)))))
+  (prove:is (let ((hook (next-hooks:make-hook-number->number :handlers (list #'add1))))
               (next-hooks:add-hook hook (next-hooks:make-handler-number->number #'add1))
               (next-hooks:run-hook hook 17))
             '(18))
-  (prove:is (let ((hook
-                        (make-instance 'next-hooks:hook-number->number
-                                       :handlers (list (next-hooks:make-handler-number->number #'add1)))))
+  (prove:is (let ((hook (next-hooks:make-hook-number->number :handlers (list #'add1))))
               (next-hooks:add-hook hook (next-hooks:make-handler-number->number (lambda (n) (+ 1 n)) :name 'add1))
               (next-hooks:run-hook hook 17))
             '(18)))
 
 (prove:subtest "Combine handlers"
-  (prove:is (let ((hook
-                        (make-instance 'next-hooks:hook-number->number
-                                       :handlers (list (next-hooks:make-handler-number->number #'add1)
-                                                       (next-hooks:make-handler-number->number #'mul2))
-                                       :combination #'next-hooks:combine-composed-hook)))
+  (prove:is (let ((hook (next-hooks:make-hook-number->number
+                         :handlers (list #'add1 #'mul2)
+                         :combination #'next-hooks:combine-composed-hook)))
               (next-hooks:run-hook hook 17))
             35)
-  (prove:is (let ((hook
-                        (make-instance 'next-hooks:hook-number->number
-                                       :combination #'next-hooks:combine-composed-hook)))
+  (prove:is (let ((hook (next-hooks:make-hook-number->number
+                         :combination #'next-hooks:combine-composed-hook)))
               (next-hooks:run-hook hook 17))
             17))
 
 (prove:subtest "Remove handler from hook"
   (prove:is (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
-                   (hook
-                     (make-instance 'next-hooks:hook-number->number
-                                    :handlers (list handler1
-                                                    (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+                   (hook (next-hooks:make-hook-number->number
+                          :handlers (list handler1
+                                          (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
               (next-hooks:remove-hook hook 'mul3)
               (next-hooks:remove-hook hook handler1)
               (next-hooks:run-hook hook 17))
@@ -81,15 +72,15 @@
 (prove:subtest "Disable hook"
   (let* ((handler1 (next-hooks:make-handler-number->number #'add1))
          (handler2 (next-hooks:make-handler-number->number #'mul2)))
-    (prove:is (let* ((hook (make-instance 'next-hooks:hook-number->number
-                                          :handlers (list handler1
-                                                          (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+    (prove:is (let* ((hook (next-hooks:make-hook-number->number
+                            :handlers (list handler1
+                                            (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
                 (next-hooks:disable-hook hook)
                 (length (next-hooks:disabled-handlers hook)))
               2)
     (prove:is (let* ((hook
-                       (make-instance 'next-hooks:hook-number->number
-                                      :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+                      (next-hooks:make-hook-number->number
+                       :handlers (list (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
                 (next-hooks:disable-hook hook)
                 (next-hooks:add-hook hook handler1)
                 (next-hooks:disable-hook hook)
@@ -97,16 +88,16 @@
                     handler1))
               t)
     (prove:is (let* ((hook
-                       (make-instance 'next-hooks:hook-number->number
-                                      :handlers (list handler1
-                                                      (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
+                       (next-hooks:make-hook-number->number
+                        :handlers (list handler1
+                                        (next-hooks:make-handler-number->number (lambda (n) (* 3 n)) :name 'mul3)))))
                 (next-hooks:disable-hook hook)
                 (next-hooks:enable-hook hook)
                 (length (next-hooks:disabled-handlers hook)))
               0)
     (prove:is (let* ((hook
-                       (make-instance 'next-hooks:hook-number->number
-                                      :handlers (list handler1 handler2))))
+                       (next-hooks:make-hook-number->number
+                        :handlers (list handler1 handler2))))
                 (next-hooks:disable-hook hook handler1)
                 (list (first (next-hooks:handlers hook))
                       (first (next-hooks:disabled-handlers hook))))

--- a/next.asd
+++ b/next.asd
@@ -163,3 +163,9 @@
                              (:file "password")
                              (:file "password-pass")
                              (:file "password-keepassxc")))))
+
+(asdf:defsystem next/hooks
+  :depends-on (alexandria serapeum)
+  :components ((:module source :pathname "libraries/hooks/"
+                :components ((:file "package")
+                             (:file "hooks")))))

--- a/next.asd
+++ b/next.asd
@@ -170,3 +170,12 @@
   :components ((:module source :pathname "libraries/hooks/"
                 :components ((:file "package")
                              (:file "hooks")))))
+
+(asdf:defsystem next/hooks/tests
+  :defsystem-depends-on (prove-asdf)
+  :depends-on (prove
+               next/hooks)
+  :components ((:module source/tests :pathname "libraries/hooks/tests/"
+                :components ((:test-file "tests"))))
+  :perform (asdf:test-op (op c) (uiop:symbol-call
+                                 :prove-asdf 'run-test-system c)))

--- a/next.asd
+++ b/next.asd
@@ -12,7 +12,6 @@
                :cl-annot
                :cl-ansi-text
                :cl-css
-               :cl-hooks
                :cl-json
                :cl-markup
                :cl-ppcre

--- a/next.asd
+++ b/next.asd
@@ -40,7 +40,8 @@
                :next/download-manager
                :next/ring
                :next/history-tree
-               :next/password-manager)
+               :next/password-manager
+               :next/hooks)
   :components ((:module "source"
                 :components
                 ((:file "patch-annot")

--- a/next.asd
+++ b/next.asd
@@ -28,6 +28,7 @@
                :mk-string-metrics
                :parenscript
                :quri
+               :serapeum
                :sqlite
                :str
                :swank

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -51,7 +51,7 @@ Set to '-' to read standard input instead.")
 
 (define-command quit ()
   "Quit Next."
-  (hooks:run-hook (hooks:object-hook *interface* 'before-exit-hook))
+  (next-hooks:run-hook (before-exit-hook *interface*))
   (kill-interface *interface*)
   (kill-port (port *interface*)))
 
@@ -227,8 +227,6 @@ Finally, run the `*after-init-hook*'."
     ;; Randomness should be seeded as early as possible to avoid generating
     ;; deterministic tokens.
     (setf *random-state* (make-random-state t))
-    ;; Reset `*after-init-hook*' or else the handlers will stack.
-    (setf *after-init-hook* nil)
     (unless (getf *options* :no-init)
       (load-lisp-file init-file :interactive (not non-interactive)))
     ;; create the interface object
@@ -257,7 +255,7 @@ PATH or set in you ~/.config/next/init.lisp, for instance:
     (setf (slot-value *interface* 'init-time)
           (local-time:timestamp-difference (local-time:now) startup-timestamp))
     (handler-case
-        (hooks:run-hook '*after-init-hook*)
+        (next-hooks:run-hook *after-init-hook*)
       (error (c)
         (log:error "In *after-init-hook*: ~a" c)))
     (handler-case

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -94,7 +94,7 @@ URL is first transformed by `parse-url', then by BUFFER's `load-hook'."
   (let ((url (if raw-url-p
                  input-url
                  (parse-url input-url))))
-    (setf url (run-composed-hook (load-hook buffer) url))
+    (setf url (next-hooks:run-hook-with-args (load-hook buffer) url))
     (setf (url buffer) url)
     (rpc-buffer-load buffer url)))
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -94,7 +94,7 @@ URL is first transformed by `parse-url', then by BUFFER's `load-hook'."
   (let ((url (if raw-url-p
                  input-url
                  (parse-url input-url))))
-    (setf url (next-hooks:run-hook-with-args (load-hook buffer) url))
+    (setf url (next-hooks:run-hook (load-hook buffer) url))
     (setf (url buffer) url)
     (rpc-buffer-load buffer url)))
 

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -50,9 +50,9 @@ Regardless of the hook, the command returns the last expression of BODY."
         (after-hook (intern (str:concat (symbol-name name) "-AFTER-HOOK"))))
     `(progn
        @export
-       (defparameter ,before-hook (make-instance 'next-hooks:hook-void))
+       (defparameter ,before-hook (next-hooks:make-hook-void))
        @export
-       (defparameter ,after-hook (make-instance 'next-hooks:hook-void))
+       (defparameter ,after-hook (next-hooks:make-hook-void))
        (unless (find-if (lambda (c) (and (eq (sym c) ',name)
                                          (eq (pkg c) *package*)))
                         %%command-list)

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -50,9 +50,9 @@ Regardless of the hook, the command returns the last expression of BODY."
         (after-hook (intern (str:concat (symbol-name name) "-AFTER-HOOK"))))
     `(progn
        @export
-       (defparameter ,before-hook '())
+       (defparameter ,before-hook (make-instance 'next-hooks:hook-void))
        @export
-       (defparameter ,after-hook '())
+       (defparameter ,after-hook (make-instance 'next-hooks:hook-void))
        (unless (find-if (lambda (c) (and (eq (sym c) ',name)
                                          (eq (pkg c) *package*)))
                         %%command-list)
@@ -64,14 +64,14 @@ Regardless of the hook, the command returns the last expression of BODY."
          ,documentation
          (handler-case
              (progn
-               (hooks:run-hook ',before-hook)
+               (next-hooks:run-hook ,before-hook)
                (log:debug "Calling command ~a." ',name)
                ;; TODO: How can we print the arglist as well?
                ;; (log:debug "Calling command (~a ~a)." ',name (list ,@arglist))
                (prog1
                    (progn
                      ,@body)
-                 (hooks:run-hook ',after-hook)))
+                 (next-hooks:run-hook ,after-hook)))
            (next-condition (c)
              (format t "~s" c)))))))
 

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -19,8 +19,9 @@ It can be initialized with
 It's possible to run multiple interfaces of Next at the same time.  You can
 let-bind *interface* to temporarily switch interface.")
 
+(declaim (type next-hooks:hook-void *after-init-hook*))
 @export
-(defvar *after-init-hook* nil
+(defvar *after-init-hook* (make-instance 'next-hooks:hook-void)
   "The entry-point object to configure everything in Next.
 The hook takes no argument.
 
@@ -29,9 +30,8 @@ This hook is run after the `*interface*' is instantiated and before the
 
 Add a handler can be added with
 
-  (hooks:add-hook '*after-init-hook* #'my-foo-function)
-
-(Mind the quote.)")
+  (next-hooks:add-hook *after-init-hook*
+    (next-hooks:make-handler-void #'my-foo-function))")
 
 @export
 (defparameter *use-session* t

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -268,7 +268,7 @@ This runs a call"
                     (write (ps:lisp (content minibuffer)))))))
 
 (defmethod initialize-instance :after ((minibuffer minibuffer) &key)
-  (hooks:run-hook (hooks:object-hook *interface* 'minibuffer-make-hook) minibuffer)
+  (next-hooks:run-hook-with-args (minibuffer-make-hook *interface*) minibuffer)
   ;; We don't want to show the input in the candidate list when invisible.
   (unless (completion-function minibuffer)
     ;; If we have no completion function, then we have no candidates beside

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -268,7 +268,7 @@ This runs a call"
                     (write (ps:lisp (content minibuffer)))))))
 
 (defmethod initialize-instance :after ((minibuffer minibuffer) &key)
-  (next-hooks:run-hook-with-args (minibuffer-make-hook *interface*) minibuffer)
+  (next-hooks:run-hook (minibuffer-make-hook *interface*) minibuffer)
   ;; We don't want to show the input in the candidate list when invisible.
   (unless (completion-function minibuffer)
     ;; If we have no completion function, then we have no candidates beside

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -54,10 +54,10 @@ The buffer is returned so that mode activation can be chained."
                        (when (constructor new-mode)
                          (funcall (constructor new-mode) new-mode))
                        (push new-mode (modes buffer))
-                       (next-hooks:run-hook-with-args (enable-hook new-mode) new-mode))
+                       (next-hooks:run-hook (enable-hook new-mode) new-mode))
                      (log:debug "~a enabled." ',name))
                    (when existing-instance
-                     (next-hooks:run-hook-with-args (disable-hook existing-instance) existing-instance)
+                     (next-hooks:run-hook (disable-hook existing-instance) existing-instance)
                      (when (destructor existing-instance)
                        (funcall (destructor existing-instance) existing-instance))
                      (setf (modes buffer) (delete existing-instance

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -66,6 +66,7 @@ The buffer is returned so that mode activation can be chained."
              buffer)))))
 
 
+(defclass root-mode () ())
 (next-hooks:define-hook-type mode (function (root-mode)))
 
 (define-mode root-mode (t)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -54,16 +54,19 @@ The buffer is returned so that mode activation can be chained."
                        (when (constructor new-mode)
                          (funcall (constructor new-mode) new-mode))
                        (push new-mode (modes buffer))
-                       (hooks:run-hook (hooks:object-hook new-mode 'enable-hook) new-mode))
+                       (next-hooks:run-hook-with-args (enable-hook new-mode) new-mode))
                      (log:debug "~a enabled." ',name))
                    (when existing-instance
-                     (hooks:run-hook (hooks:object-hook existing-instance 'disable-hook) existing-instance)
+                     (next-hooks:run-hook-with-args (disable-hook existing-instance) existing-instance)
                      (when (destructor existing-instance)
                        (funcall (destructor existing-instance) existing-instance))
                      (setf (modes buffer) (delete existing-instance
                                                   (modes buffer)))
                      (log:debug "~a disabled." ',name))))
              buffer)))))
+
+
+(next-hooks:define-hook-type mode (function (root-mode)))
 
 (define-mode root-mode (t)
   "The root of all modes."
@@ -77,13 +80,15 @@ It takes the mode as argument.")
                :documentation
                "A lambda function which tears down the mode upon deactivation.
 It takes the mode as argument.")
-   (enable-hook :accessor enable-hook :initarg :enable-hook :type :list
-                :initform '()
+   (enable-hook :accessor enable-hook :initarg :enable-hook
+                :initform (make-instance 'hook-mode)
+                :type hook-mode
                 :documentation "This hook is run when enabling the mode.
 It takes the mode as argument
 It is run before the destructor.")
-   (disable-hook :accessor disable-hook :initarg :disable-hook :type :list
-                 :initform '()
+   (disable-hook :accessor disable-hook :initarg :disable-hook
+                 :initform (make-instance 'hook-mode)
+                 :type hook-mode
                  :documentation "This hook is run when disabling the mode.
 It takes the mode as argument.
 It is run before the destructor.")

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -82,13 +82,13 @@ It takes the mode as argument.")
                "A lambda function which tears down the mode upon deactivation.
 It takes the mode as argument.")
    (enable-hook :accessor enable-hook :initarg :enable-hook
-                :initform (make-instance 'hook-mode)
+                :initform (make-hook-mode)
                 :type hook-mode
                 :documentation "This hook is run when enabling the mode.
 It takes the mode as argument
 It is run before the destructor.")
    (disable-hook :accessor disable-hook :initarg :disable-hook
-                 :initform (make-instance 'hook-mode)
+                 :initform (make-hook-mode)
                  :type hook-mode
                  :documentation "This hook is run when disabling the mode.
 It takes the mode as argument.

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -6,7 +6,11 @@
 (annot:enable-annot-syntax)
 
 ;; Create necessary hook types.
-;; TODO: Is it OK to use WINDOW and BUFFER before their declaration?
+;; We must forward-declare the class since the hook take the type of the class
+;; that hosts them.
+(defclass buffer () ())
+(defclass minibuffer () ())
+(defclass window () ())
 (next-hooks:define-hook-type window (function (window)))
 (next-hooks:define-hook-type buffer (function (buffer)))
 (next-hooks:define-hook-type minibuffer (function (minibuffer)))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -570,7 +570,7 @@ when `proxied-downloads-p' is true."
   "Download URI.
 When PROXY-ADDRESS is :AUTO (the default), the proxy address is guessed from the
 current buffer."
-  (next-hooks:run-hook-with-args (before-download-hook *interface*) url)
+  (next-hooks:run-hook (before-download-hook *interface*) url)
   (when (eq proxy-address :auto)
     (setf proxy-address (proxy-address (current-buffer)
                                        :downloads-only t)))
@@ -721,7 +721,7 @@ Run INTERFACE's `window-make-hook' over the created window."
       ;; When starting from a REPL, it's possible that the window is spawned in
       ;; the background and rpc-window-active would then return nil.
       (setf (last-active-window *interface*) window))
-    (next-hooks:run-hook-with-args (window-make-hook *interface*) window)
+    (next-hooks:run-hook (window-make-hook *interface*) window)
     window))
 
 (declaim (ftype (function (window string)) rpc-window-set-title))
@@ -759,7 +759,7 @@ INTERFACE's `window-delete-hook' over WINDOW."
   "Set INTERFACE's WINDOW buffer to BUFFER.
 Run WINDOW's `window-set-active-buffer-hook' over WINDOW and BUFFER before
 proceeding."
-  (next-hooks:run-hook-with-args (window-set-active-buffer-hook window) window buffer)
+  (next-hooks:run-hook (window-set-active-buffer-hook window) window buffer)
   (%rpc-send "window_set_active_buffer" (id window) (id buffer))
   (setf (active-buffer window) buffer)
   (when (and window buffer)
@@ -816,7 +816,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
                      (apply #'make-instance *buffer-class* :id (get-unique-buffer-identifier)
                             (append (when title `(:title ,title))
                                     (when default-modes `(:default-modes ,default-modes)))))))
-    (next-hooks:run-hook-with-args (buffer-before-make-hook *interface*) buffer)
+    (next-hooks:run-hook (buffer-before-make-hook *interface*) buffer)
     (unless (str:emptyp (namestring (cookies-path buffer)))
       (ensure-parent-exists (cookies-path buffer)))
     (setf (gethash (id buffer) (buffers *interface*)) buffer)
@@ -829,7 +829,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
       (setf (last-active-buffer *interface*) buffer))
     ;; Run hooks before `initialize-modes' to allow for last-minute modification
     ;; of the default modes.
-    (next-hooks:run-hook-with-args (buffer-make-hook *interface*) buffer)
+    (next-hooks:run-hook (buffer-make-hook *interface*) buffer)
     ;; Modes might require that buffer exists, so we need to initialize them
     ;; after it has been created on the platform port.
     (initialize-modes buffer)
@@ -850,7 +850,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
 (defun rpc-buffer-delete (buffer)
   "Delete BUFFER from `*interface*'.
 Run BUFFER's `buffer-delete-hook' over BUFFER before deleting it."
-  (next-hooks:run-hook-with-args (buffer-delete-hook buffer) buffer)
+  (next-hooks:run-hook (buffer-delete-hook buffer) buffer)
   (let ((parent-window (find-if
                         (lambda (window) (eql (active-buffer window) buffer))
                         (alexandria:hash-table-values (windows *interface*))))
@@ -1014,7 +1014,7 @@ TODO: Only booleans are supported for now."
          (window (gethash window-id windows)))
     (log:debug "Closing window ID ~a (new total: ~a)" window-id
                (1- (hash-table-count windows)))
-    (next-hooks:run-hook-with-args (window-delete-hook window) window)
+    (next-hooks:run-hook (window-delete-hook window) window)
     (remhash window-id windows))
   (values))
 

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -37,12 +37,12 @@ current URL or event messages.")
                            :type integer
                            :documentation "The height of the minibuffer when open.")
    (window-set-active-buffer-hook :accessor window-set-active-buffer-hook
-                                  :initform (make-instance 'hook-window-buffer)
+                                  :initform (make-hook-window-buffer)
                                   :type hook-window-buffer
                                   :documentation "Hook run before `rpc-window-set-active-buffer' takes effect.
 The handlers take the window and the buffer as argument.")
    (window-delete-hook :accessor window-delete-hook
-                       :initform (make-instance 'hook-window)
+                       :initform (make-hook-window)
                        :type hook-window
                        :documentation "Hook run after `rpc-window-delete' takes effect.
 The handlers take the window as argument.")))
@@ -180,14 +180,14 @@ platform ports might support this.")
           :documentation "Proxy for buffer.")
    ;; TODO: Rename `load-hook' to `set-url-hook'?
    (load-hook :accessor load-hook
-              :initform (make-instance 'next-hooks:hook-string->string
-                                       :combination #'next-hooks:combine-composed-hook)
+              :initform (next-hooks:make-hook-string->string
+                         :combination #'next-hooks:combine-composed-hook)
               :type next-hooks:hook-string->string
               :documentation "Hook run in `set-url' after `parse-url' was
 processed.  The handlers take the URL going to be loaded as argument and must
 return a (possibly new) URL.")
    (buffer-delete-hook :accessor buffer-delete-hook
-                       :initform (make-instance 'hook-buffer)
+                       :initform (make-hook-buffer)
                        :type hook-buffer
                        :documentation "Hook run before `rpc-buffer-delete' takes effect.
 The handlers take the buffer as argument.")))
@@ -422,24 +422,24 @@ into `session-path'.")
 from `session-path'.")
    ;; Hooks follow:
    (before-exit-hook :accessor before-exit-hook
-                     :initform (make-instance 'next-hooks:hook-void)
+                     :initform (next-hooks:make-hook-void)
                      :type next-hooks:hook-void
                      :documentation "Hook run before both `*interface*' and the
 platform port get terminated.  The handlers take no argument.")
    (window-make-hook :accessor window-make-hook
-                     :initform (make-instance 'hook-window)
+                     :initform (make-hook-window)
                      :type hook-window
                      :documentation "Hook run after `rpc-window-make'.
 The handlers take the window as argument.")
    (buffer-make-hook :accessor buffer-make-hook
-                     :initform (make-instance 'hook-buffer)
+                     :initform (make-hook-buffer)
                      :type hook-buffer
                      :documentation "Hook run after `rpc-buffer-make' and before `rpc-buffer-load'.
 It is run before `initialize-modes' so that the default mode list can still be
 altered from the hooks.
 The handlers take the buffer as argument.")
    (buffer-before-make-hook :accessor buffer-before-make-hook
-                            :initform (make-instance 'hook-buffer)
+                            :initform (make-hook-buffer)
                             :type hook-buffer
                             :documentation "Hook run before `rpc-buffer-make'.
 This hook is mostly useful to set the `cookies-path'.
@@ -447,18 +447,18 @@ The buffer web view is not allocated, so it's not possible to run any
 parenscript from this hook.  See `buffer-make-hook' for a hook.
 The handlers take the buffer as argument.")
    (minibuffer-make-hook :accessor minibuffer-make-hook
-                         :initform (make-instance 'hook-minibuffer)
+                         :initform (make-hook-minibuffer)
                          :type hook-minibuffer
                          :documentation "Hook run after the `minibuffer' class
 is instantiated and before initializing the minibuffer modes.
 The handlers take the minibuffer as argument.")
    (before-download-hook :accessor before-download-hook
-                         :initform (make-instance 'hook-download)
+                         :initform (make-hook-download)
                          :type hook-download
                          :documentation "Hook run before downloading a URL.
 The handlers take the URL as argument.")
    (after-download-hook :accessor after-download-hook
-                        :initform (make-instance 'hook-download)
+                        :initform (make-hook-download)
                         :type hook-download
                         :documentation "Hook run after a download has completed.
 The handlers take the `download-manager:download' class instance as argument.")))

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -147,17 +147,6 @@ won't be affected."
     (error ()
       (error "~a not found" program))))
 
-;; TODO: Backport upstream?  See https://github.com/scymtym/architecture.hooks/issues/2.
-;; TODO: For now the user has no way to choose between `hooks:run-hook' and
-;; `next:run-composed-hook'.
-(defun run-composed-hook (hook &rest args)
-  "Compose all handlers in HOOK and call the resulting function over ARGS."
-  (if hook
-      (apply (apply #'alexandria:compose hook) args)
-      ;; We return values so that this is equivalent to #'identity when there is
-      ;; no hook.
-      (apply #'values args)))
-
 @export
 (defun notify (msg)
   "Echo this message and display it with a desktop notification system (notify-send on linux, terminal-notifier on macOs)."


### PR DESCRIPTION
Work in progress, not done yet.

So I've addressed many of the points mentioned in #419.
Those hooks are based off Serapeum's hooks.  They fix most (all?) issues in #383. 

The biggest issue I'm facing at the moment is type-checking: I'd like to check that the handlers match the type specified in the the `hook` object, but it seems impossible to do in Common Lisp:

https://old.reddit.com/r/Common_Lisp/comments/ds4tpy/programmable_and_compiletime_function_typechecking/?

This is a general issue: how do we validate the type of a variable / slot that's supposed to host a function?



I've implemented some form of global, ahead-of-time hooks that can be bound to any symbol / object.  It's a very naive implementation, I don't know if that would suit everyone's needs.

This implementation makes some parts of Serapeum's hooks irrelevant, such as `run-hook-with-args` and derivatives.

@ruricolist @scymtym What do you think?