### PR TITLE
CLOS-style configuration

### DIFF
--- a/source/base.lisp
+++ b/source/base.lisp
@@ -189,8 +189,8 @@ useful when Next starts up)."
 If INTERACTIVE is t, allow the debugger on errors. If :running, show an error but don't quit the lisp process.
 "
   (with-result (file-name-input (read-from-minibuffer
-                                 (make-instance 'minibuffer
-                                                :input-prompt "Load file:")))
+                                 (make-minibuffer
+                                  :input-prompt "Load file:")))
     (load-lisp-file file-name-input :interactive :running)))
 
 (define-command load-init-file (&key (init-file (init-file-path))

--- a/source/base.lisp
+++ b/source/base.lisp
@@ -234,10 +234,10 @@ Finally, run the `*after-init-hook*'."
     (when *interface*
       (kill-interface *interface*)
       ;; It's important to set it to nil or else if we re-run this function,
-      ;; (make-instance 'remote-interface) will be run while an existing
+      ;; (make-instance *remote-interface-class*) will be run while an existing
       ;; *interface* is still floating around.
       (setf *interface* nil))
-    (setf *interface* (make-instance 'remote-interface
+    (setf *interface* (make-instance *remote-interface-class*
                                      :non-interactive non-interactive
                                      :startup-timestamp startup-timestamp))
     ;; Start the port after the interface so that we don't overwrite the log when

--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -135,11 +135,11 @@ This can be useful to let the user select no tag when returning directly."
   "Bookmark the URL of BUFFER."
   (if (url buffer)
       (with-result (tags (read-from-minibuffer
-                          (make-instance 'minibuffer
-                                         :input-prompt "Space-separated tag(s):"
-                                         :multi-selection-p t
-                                         :completion-function (tag-completion-filter :with-empty-tag t)
-                                         :empty-complete-immediate t)))
+                          (make-minibuffer
+                           :input-prompt "Space-separated tag(s):"
+                           :multi-selection-p t
+                           :completion-function (tag-completion-filter :with-empty-tag t)
+                           :empty-complete-immediate t)))
         (when tags
           ;; Turn tags with spaces into multiple tags.
           (setf tags (alexandria:flatten
@@ -155,26 +155,26 @@ This can be useful to let the user select no tag when returning directly."
 (define-command bookmark-page ()
   "Bookmark the currently opened page(s) in the active buffer."
   (with-result (buffers (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Bookmark URL from buffer(s):"
-                                        :multi-selection-p t
-                                        :completion-function (buffer-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Bookmark URL from buffer(s):"
+                          :multi-selection-p t
+                          :completion-function (buffer-completion-filter))))
     (mapcar #'bookmark-current-page buffers)))
 
 (define-command bookmark-url ()
   "Allow the user to bookmark a URL via minibuffer input."
   (with-result (url (read-from-minibuffer
-                     (make-instance 'minibuffer
-                                    :input-prompt "Bookmark URL:")))
+                     (make-minibuffer
+                      :input-prompt "Bookmark URL:")))
     (bookmark-add url)))
 
 (define-command bookmark-delete ()
   "Delete bookmark(s)."
   (with-result (entries (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Delete bookmark(s):"
-                                        :multi-selection-p t
-                                        :completion-function (bookmark-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Delete bookmark(s):"
+                          :multi-selection-p t
+                          :completion-function (bookmark-completion-filter))))
     (setf (bookmarks-data *interface*)
           (set-difference (bookmarks-data *interface*) entries :test #'equals))))
 
@@ -182,9 +182,9 @@ This can be useful to let the user select no tag when returning directly."
   "Show link hints on screen, and allow the user to bookmark one"
   (with-result* ((links-json (add-link-hints))
                  (selected-hint (read-from-minibuffer
-                                 (make-instance 'minibuffer
-                                                :input-prompt "Bookmark hint:"
-                                                :cleanup-function #'remove-link-hints))))
+                                 (make-minibuffer
+                                  :input-prompt "Bookmark hint:"
+                                  :cleanup-function #'remove-link-hints))))
     (let* ((link-hints (cl-json:decode-json-from-string links-json))
            (selected-link (cadr (assoc selected-hint link-hints :test #'equalp))))
       (when selected-link
@@ -197,9 +197,9 @@ This can be useful to let the user select no tag when returning directly."
 (define-command set-url-from-bookmark ()
   "Set the URL for the current buffer from a bookmark."
   (with-result (entry (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Open bookmark:"
-                                      :completion-function (bookmark-completion-filter))))
+                       (make-minibuffer
+                        :input-prompt "Open bookmark:"
+                        :completion-function (bookmark-completion-filter))))
     ;; TODO: Add support for multiple bookmarks?
     (set-url (url entry) :buffer (current-buffer) :raw-url-p t)))
 

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -48,10 +48,10 @@ MODES is a list of mode symbols."
 (define-command switch-buffer ()
   "Switch the active buffer in the current window."
   (with-result (buffer (read-from-minibuffer
-                        (make-instance 'minibuffer
-                                       :input-prompt "Switch to buffer:"
-                                       ;; For commodity, the current buffer shouldn't be the first one on the list.
-                                       :completion-function (buffer-completion-filter :current-is-last-p t))))
+                        (make-minibuffer
+                         :input-prompt "Switch to buffer:"
+                         ;; For commodity, the current buffer shouldn't be the first one on the list.
+                         :completion-function (buffer-completion-filter :current-is-last-p t))))
     (set-current-buffer buffer)))
 
 (define-command make-buffer-focus ()
@@ -67,10 +67,10 @@ MODES is a list of mode symbols."
 (define-command delete-buffer ()
   "Delete the buffer(s) via minibuffer input."
   (with-result (buffers (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Delete buffer(s):"
-                                        :multi-selection-p t
-                                        :completion-function (buffer-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Delete buffer(s):"
+                          :multi-selection-p t
+                          :completion-function (buffer-completion-filter))))
     (mapcar #'rpc-buffer-delete buffers)))
 
 (define-command delete-current-buffer (&optional (buffer (current-buffer)))
@@ -113,11 +113,11 @@ URL is first transformed by `parse-url', then by BUFFER's `load-hook'."
     (when history
       (ring:insert history (url (current-buffer))))
     (with-result (url (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Open URL in buffer:"
-                                        :completion-function (history-completion-filter)
-                                        :history history
-                                        :empty-complete-immediate t)))
+                       (make-minibuffer
+                        :input-prompt "Open URL in buffer:"
+                        :completion-function (history-completion-filter)
+                        :history history
+                        :empty-complete-immediate t)))
       (when (typep url 'history-entry)
         ;; In case read-from-minibuffer returned a string upon
         ;; empty-complete-immediate.
@@ -135,10 +135,10 @@ URL is first transformed by `parse-url', then by BUFFER's `load-hook'."
 (define-command reload-buffer ()
   "Reload queried buffer(s)."
   (with-result (buffers (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Reload buffer(s):"
-                                        :multi-selection-p t
-                                        :completion-function (buffer-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Reload buffer(s):"
+                          :multi-selection-p t
+                          :completion-function (buffer-completion-filter))))
     (mapcar #'reload-current-buffer buffers)))
 
 (defmethod get-active-buffer-index ((active-buffer buffer) buffers)
@@ -190,10 +190,10 @@ item in the list, jump to the first item."
 (define-command disable-mode-for-current-buffer (&key (buffers (list (current-buffer))))
   "Disable queried mode(s)."
   (with-result (modes (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Disable mode(s):"
-                                      :multi-selection-p t
-                                      :completion-function (active-mode-completion-filter buffers))))
+                       (make-minibuffer
+                        :input-prompt "Disable mode(s):"
+                        :multi-selection-p t
+                        :completion-function (active-mode-completion-filter buffers))))
     (dolist (buffer buffers)
       (dolist (mode modes)
         (funcall (sym (mode-command mode))
@@ -202,19 +202,19 @@ item in the list, jump to the first item."
 (define-command disable-mode-for-buffer ()
   "Disable queried mode(s) for select buffer(s)."
   (with-result (buffers (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Disable mode(s) for buffer(s):"
-                                        :multi-selection-p t
-                                        :completion-function (buffer-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Disable mode(s) for buffer(s):"
+                          :multi-selection-p t
+                          :completion-function (buffer-completion-filter))))
     (disable-mode-for-current-buffer :buffers buffers)))
 
 (define-command enable-mode-for-current-buffer (&key (buffers (list (current-buffer))))
   "Enable queried mode(s)."
   (with-result (modes (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Enable mode(s):"
-                                        :multi-selection-p t
-                                        :completion-function (inactive-mode-completion-filter buffers))))
+                       (make-minibuffer
+                        :input-prompt "Enable mode(s):"
+                        :multi-selection-p t
+                        :completion-function (inactive-mode-completion-filter buffers))))
     (dolist (buffer buffers)
       (dolist (mode modes)
         (funcall (sym (mode-command mode))
@@ -223,8 +223,8 @@ item in the list, jump to the first item."
 (define-command enable-mode-for-buffer ()
   "Enable queried mode(s) for select buffer(s)."
   (with-result (buffers (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Enable mode(s) for buffer(s):"
-                                        :multi-selection-p t
-                                        :completion-function (buffer-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Enable mode(s) for buffer(s):"
+                          :multi-selection-p t
+                          :completion-function (buffer-completion-filter))))
     (enable-mode-for-current-buffer :buffers buffers)))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -189,8 +189,8 @@ This function can be `funcall'ed."
 (define-command execute-command ()
   "Execute a command by name."
   (with-result (command (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Execute command:"
-                                        :completion-function 'command-completion-filter)))
+                         (make-minibuffer
+                          :input-prompt "Execute command:"
+                          :completion-function 'command-completion-filter)))
     (setf (access-time command) (get-internal-real-time))
     (run command)))

--- a/source/download-mode.lisp
+++ b/source/download-mode.lisp
@@ -86,7 +86,7 @@
 Ask the user to choose one of the downloaded files of the current session.
 See also `open-file'."
   (with-result (filename (read-from-minibuffer
-                          (make-instance 'minibuffer
-                                         :input-prompt "Open file:"
-                                         :completion-function (downloaded-files-completion-filter))))
+                          (make-minibuffer
+                           :input-prompt "Open file:"
+                           :completion-function (downloaded-files-completion-filter))))
     (next/file-manager-mode:open-file-function filename)))

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -152,9 +152,9 @@ Note: this feature is alpha, get in touch for more!"
   (let ((directory next/file-manager-mode::*current-directory*))
     ;; Allow the current minibuffer to recognize our keybindings.
     (with-result (filename (read-from-minibuffer
-                            (make-instance 'minibuffer
-                                           :default-modes '(next/file-manager-mode::file-manager-mode minibuffer-mode)
-                                           :input-prompt (file-namestring directory)
-                                           :completion-function #'next/file-manager-mode::open-file-from-directory-completion-filter)))
+                            (make-minibuffer
+                             :default-modes '(next/file-manager-mode::file-manager-mode minibuffer-mode)
+                             :input-prompt (file-namestring directory)
+                             :completion-function #'next/file-manager-mode::open-file-from-directory-completion-filter)))
 
       (funcall next/file-manager-mode::*open-file-function* (namestring filename)))))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -14,7 +14,7 @@
   "The entry-point object to a complete instance of Next.
 It can be initialized with
 
-  (setf *interface* (make-instance 'remote-interface))
+  (setf *interface* (make-instance *remote-interface-class*))
 
 It's possible to run multiple interfaces of Next at the same time.  You can
 let-bind *interface* to temporarily switch interface.")

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -33,9 +33,9 @@
 (define-command variable-inspect ()
   "Inspect a variable and show it in a help buffer."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :completion-function #'variable-completion-filter
-                                      :input-prompt "Inspect variable:")))
+                       (make-minibuffer
+                        :completion-function #'variable-completion-filter
+                        :input-prompt "Inspect variable:")))
     (let* ((help-buffer (make-buffer
                          :title (str:concat "*Help-" (symbol-name input) "*")
                          :modes (cons 'help-mode
@@ -48,15 +48,15 @@
            (insert-help (ps:ps (setf (ps:@ document Body |innerHTML|)
                                      (ps:lisp help-contents)))))
       (rpc-buffer-evaluate-javascript help-buffer insert-help)
-   (set-current-buffer help-buffer))))
+      (set-current-buffer help-buffer))))
 
 ;; TODO: Have both "function-inspect" and "command-inspect"?
 (define-command command-inspect ()
   "Inspect a function and show it in a help buffer."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Inspect command:"
-                                      :completion-function #'function-completion-filter)))
+                       (make-minibuffer
+                        :input-prompt "Inspect command:"
+                        :completion-function #'function-completion-filter)))
     (let* ((help-buffer (make-buffer
                          :title (str:concat "*Help-" (symbol-name (sym input)) "*")
                          :modes (cons 'help-mode
@@ -85,8 +85,8 @@ This does not use an implicit PROGN to allow evaluating top-level expressions."
 (define-command command-evaluate ()
   "Evaluate a form."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Evaluate Lisp:")))
+                       (make-minibuffer
+                        :input-prompt "Evaluate Lisp:")))
     (let* ((result-buffer (make-buffer
                            :title "*List Evaluation*" ; TODO: Reuse buffer / create REPL mode.
                            :modes (cons 'help-mode

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -70,11 +70,11 @@ The history is sorted by last access."
 (define-command delete-history-entry ()
   "Delete queried history entries."
   (with-result (entries (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Delete entries:"
-                                        :completion-function (history-completion-filter)
-                                        :history (minibuffer-set-url-history *interface*)
-                                        :multi-selection-p t)))
+                         (make-minibuffer
+                          :input-prompt "Delete entries:"
+                          :completion-function (history-completion-filter)
+                          :history (minibuffer-set-url-history *interface*)
+                          :multi-selection-p t)))
     (dolist (entry entries)
       (remhash (url entry) (history-data *interface*)))
     ;; Use accessor to ensure store function is called.

--- a/source/jump-heading.lisp
+++ b/source/jump-heading.lisp
@@ -43,10 +43,10 @@ For example, Wikipedia ones end with '[edit]'. We strip what comes after the fir
   "Jump to a particular heading, of type h1, h2, h3, h4, h5, or h6."
   (with-result* ((headings (get-headings))
                  (heading (read-from-minibuffer
-                           (make-instance 'minibuffer
-                                          :input-prompt "Jump to heading:"
-                                          :completion-function (lambda (input)
-                                                                 (fuzzy-match
-                                                                  input
-                                                                  (make-headings (cl-json:decode-json-from-string headings))))))))
+                           (make-minibuffer
+                            :input-prompt "Jump to heading:"
+                            :completion-function (lambda (input)
+                                                   (fuzzy-match
+                                                    input
+                                                    (make-headings (cl-json:decode-json-from-string headings))))))))
     (paren-jump-to-heading :heading-inner-text (inner-text heading))))

--- a/source/link-hint.lisp
+++ b/source/link-hint.lisp
@@ -104,10 +104,10 @@
 (defmacro query-hints (prompt (symbol) &body body)
   `(with-result* ((links-json (add-link-hints))
                   (selected-hint (read-from-minibuffer
-                                  (make-instance 'minibuffer
-                                                 :input-prompt ,prompt
-                                                 :history nil
-                                                 :cleanup-function #'remove-link-hints))))
+                                  (make-minibuffer
+                                   :input-prompt ,prompt
+                                   :history nil
+                                   :cleanup-function #'remove-link-hints))))
      (let* ((link-hints (cl-json:decode-json-from-string links-json))
             (,symbol (cadr (assoc selected-hint link-hints :test #'equalp))))
        (when ,symbol

--- a/source/macro.lisp
+++ b/source/macro.lisp
@@ -36,8 +36,8 @@ ASYNC-FORM is a function that has at least a :CALLBACK key argument.
 Example:
 
   (with-result (url (read-from-minibuffer
-                     (make-instance 'minibuffer
-                                    :input-prompt \"Bookmark URL:\"))
+                     (make-minibuffer
+                      :input-prompt \"Bookmark URL:\"))
     (bookmark-add url))"
   `(,(first async-form)
     ,@(rest async-form)
@@ -51,9 +51,9 @@ Example:
 
   (with-result* ((links-json (add-link-hints))
                  (selected-hint (read-from-minibuffer
-                                 (make-instance 'minibuffer
-                                                :input-prompt \"Bookmark hint:\"
-                                                :cleanup-function #'remove-link-hints))))
+                                 (make-minibuffer
+                                  :input-prompt \"Bookmark hint:\"
+                                  :cleanup-function #'remove-link-hints))))
     ...)"
   (if (null bindings)
     `(progn ,@body)

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -176,6 +176,9 @@ You might want to configure the value on HiDPI screen.")
                                              :color "white")))
                      :documentation "The CSS applied to a minibuffer when it is set-up.")))
 
+@export
+(defparameter *minibuffer-class* 'minibuffer)
+
 (defmethod (setf input-buffer) (value (minibuffer minibuffer))
   "Reset the minibuffer state on every input change.
 This is necessary or else completion cursor / head could be beyond the updated

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -178,6 +178,58 @@ You might want to configure the value on HiDPI screen.")
 
 @export
 (defparameter *minibuffer-class* 'minibuffer)
+@export
+(defun make-minibuffer (&key
+                          (default-modes nil explicit-default-modes)
+                          (completion-function nil explicit-completion-function)
+                          (callback nil explicit-callback)
+                          (callback-buffer nil explicit-callback-buffer)
+                          (setup-function nil explicit-setup-function)
+                          (cleanup-function nil explicit-cleanup-function)
+                          (empty-complete-immediate nil explicit-empty-complete-immediate)
+                          (input-prompt nil explicit-input-prompt)
+                          (input-buffer nil explicit-input-buffer)
+                          (invisible-input-p nil explicit-invisible-input-p)
+                          (history nil explicit-history)
+                          (multi-selection-p nil explicit-multi-selection-p))
+  "See the `minibuffer' class for the argument documentation."
+  (apply #'make-instance *minibuffer-class*
+         `(,@(if explicit-default-modes
+                `(:default-modes ,default-modes)
+                '())
+           ,@(if explicit-completion-function
+                `(:completion-function ,completion-function)
+                '())
+           ,@(if explicit-callback
+                `(:callback ,callback)
+                '())
+           ,@(if explicit-callback-buffer
+                `(:callback-buffer ,callback-buffer)
+                '())
+           ,@(if explicit-setup-function
+                `(:setup-function ,setup-function)
+                '())
+           ,@(if explicit-cleanup-function
+                `(:cleanup-function ,cleanup-function)
+                '())
+           ,@(if explicit-empty-complete-immediate
+                `(:empty-complete-immediate ,empty-complete-immediate)
+                '())
+           ,@(if explicit-input-prompt
+                `(:input-prompt ,input-prompt)
+                '())
+           ,@(if explicit-input-buffer
+                `(:input-buffer ,input-buffer)
+                '())
+           ,@(if explicit-invisible-input-p
+                `(:invisible-input-p ,invisible-input-p)
+                '())
+           ,@(if explicit-history
+                `(:history ,history)
+                '())
+           ,@(if explicit-multi-selection-p
+                `(:multi-selection-p ,multi-selection-p)
+                '()))))
 
 (defmethod (setf input-buffer) (value (minibuffer minibuffer))
   "Reset the minibuffer state on every input change.
@@ -235,8 +287,8 @@ This runs a call"
 Example use:
 
   (read-from-minibuffer
-   (make-instance 'minibuffer
-                  :completion-function #'my-completion-filter))
+   (make-minibuffer
+    :completion-function #'my-completion-filter))
 
 See the documentation of `minibuffer' to know more about the minibuffer options."
   (when callback
@@ -801,10 +853,10 @@ Return most recent entry in RING."
   "Choose a minibuffer input history entry to insert as input."
   (when (history minibuffer)
     (with-result (input (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Input history:"
-                                        :history nil
-                                        :completion-function (minibuffer-history-completion-filter (history minibuffer)))))
+                         (make-minibuffer
+                          :input-prompt "Input history:"
+                          :history nil
+                          :completion-function (minibuffer-history-completion-filter (history minibuffer)))))
       (unless (str:empty? input)
         (log:debug input minibuffer)
         (setf (input-buffer minibuffer) "")

--- a/source/password.lisp
+++ b/source/password.lisp
@@ -9,12 +9,12 @@
   "Save password to password interface."
   (if (password-interface *interface*)
       (with-result* ((password-name (read-from-minibuffer
-                                     (make-instance 'minibuffer
-                                                    :input-prompt "Name for new password:")))
+                                     (make-minibuffer
+                                      :input-prompt "Name for new password:")))
                      (new-password (read-from-minibuffer
-                                    (make-instance 'minibuffer
-                                                   :invisible-input-p t
-                                                   :input-prompt "New password (leave empty to generate):"))))
+                                    (make-minibuffer
+                                     :invisible-input-p t
+                                     :input-prompt "New password (leave empty to generate):"))))
         (password:save-password (password-interface *interface*)
                                 password-name
                                 new-password))
@@ -30,9 +30,9 @@
       (with-password (password-interface *interface*)
         (with-result (password-name
                       (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :completion-function
-                                      (copy-password-completion-filter
-                                       (password-interface *interface*)))))
+                       (make-minibuffer
+                        :completion-function
+                        (copy-password-completion-filter
+                         (password-interface *interface*)))))
           (password:clip-password (password-interface *interface*) password-name)))
       (echo-warning "No password manager found.")))

--- a/source/proxy-mode.lisp
+++ b/source/proxy-mode.lisp
@@ -6,7 +6,7 @@
 
 @export
 (defparameter *default-proxy*
-  (make-instance 'proxy
+  (make-instance next::*proxy-class*
                  :server-address "socks5://127.0.0.1:9050"
                  :whitelist '("localhost" "localhost:8080")
                  :proxied-downloads-p t))

--- a/source/recent-buffers.lisp
+++ b/source/recent-buffers.lisp
@@ -18,10 +18,10 @@
 (define-command reopen-buffer ()
   "Reopen queried deleted buffer(s)."
   (with-result (buffers (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Reopen buffer(s):"
-                                        :multi-selection-p t
-                                        :completion-function (recent-buffer-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Reopen buffer(s):"
+                          :multi-selection-p t
+                          :completion-function (recent-buffer-completion-filter))))
     (dolist (buffer buffers)
       (ring:delete-match (recent-buffers *interface*) (buffer-match-predicate buffer))
       (reload-current-buffer (rpc-buffer-make :dead-buffer buffer))

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -13,7 +13,7 @@
    (active-minibuffers :accessor active-minibuffers :initform nil
                        :documentation "The stack of currently active minibuffers.")
    (status-buffer :accessor status-buffer ;; TODO: Use a separate class for status bars once the platform port has a separate display.
-                  :initform (make-instance 'minibuffer)
+                  :initform (make-minibuffer)
                   :documentation "Buffer for displaying information such as
 current URL or event messages.")
    (status-buffer-height :accessor status-buffer-height :initform 36

--- a/source/remote.lisp
+++ b/source/remote.lisp
@@ -31,6 +31,17 @@ The handlers take the window and the buffer as argument.")
                        :documentation "Hook run after `rpc-window-delete' takes effect.
 The handlers take the window as argument.")))
 
+;; TODO: Compile-time type-checking with `satisfies' only works at the
+;; top-level with SBCL.
+;; (defun window-class-symbol-p (class-symbol)
+;;   (closer-mop:subclassp (find-class class-symbol)
+;;                         (find-class 'window)))
+;; (deftype window-type ()
+;;   `(satisfies window-class-symbol-p))
+;; (declaim (type (window-type) *window-class*))
+@export
+(defparameter *window-class* 'window)
+
 @export
 @export-accessors
 (defclass proxy ()
@@ -54,6 +65,9 @@ It must be a list of strings.")
 the proxy."))
   (:documentation "Enable forwarding of all network requests to a specific host.
 This can apply to specific buffer."))
+
+@export
+(defparameter *proxy-class* 'proxy)
 
 @export
 @export-accessors
@@ -160,6 +174,9 @@ return a (possibly new) URL.")
    (buffer-delete-hook :accessor buffer-delete-hook :initform '() :type list
                        :documentation "Hook run before `rpc-buffer-delete' takes effect.
 The handlers take the buffer as argument.")))
+
+@export
+(defparameter *buffer-class* 'buffer)
 
 (defmethod proxy ((buffer buffer))
   (slot-value buffer 'proxy))
@@ -415,6 +432,9 @@ The handlers take the URL as argument.")
                         :documentation "Hook run after a download has completed.
 The handlers take the `download-manager:download' class instance as argument.")))
 
+@export
+(defparameter *remote-interface-class* 'remote-interface)
+
 ;; Catch a common case for a better error message.
 (defmethod buffers :before ((interface t))
   (when (null interface)
@@ -660,7 +680,7 @@ For an array of string, that would be \"as\"."
   "Create a window and return the window object.
 Run INTERFACE's `window-make-hook' over the created window."
   (let* ((window-id (get-unique-window-identifier))
-         (window (make-instance 'window :id window-id)))
+         (window (make-instance *window-class* :id window-id)))
     (setf (gethash window-id (windows *interface*)) window)
     (incf (total-window-count *interface*))
     (%rpc-send "window_make" window-id)
@@ -760,7 +780,7 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
   (let* ((buffer (if dead-buffer
                      (progn (setf (id dead-buffer) (get-unique-buffer-identifier))
                             dead-buffer)
-                     (apply #'make-instance 'buffer :id (get-unique-buffer-identifier)
+                     (apply #'make-instance *buffer-class* :id (get-unique-buffer-identifier)
                             (append (when title `(:title ,title))
                                     (when default-modes `(:default-modes ,default-modes)))))))
     (hooks:run-hook (hooks:object-hook *interface* 'buffer-before-make-hook) buffer)

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -76,9 +76,9 @@ returns
   "Add search boxes for a given search string."
   (initialize-search-buffer)
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Search for:"
-                                      :history (minibuffer-search-history *interface*))))
+                       (make-minibuffer
+                        :input-prompt "Search for:"
+                        :history (minibuffer-search-history *interface*))))
     (%remove-search-hints)
     (%add-search-hints
      :search-string input

--- a/source/vcs-mode.lisp
+++ b/source/vcs-mode.lisp
@@ -176,9 +176,9 @@ Ask for which directory to clone to, expect if there is one single choice."
        (setf target-dir (first next/vcs::*vcs-projects-roots*))
        (next/vcs::clone project-name root-name target-dir clone-uri))
       (t (with-result (target-dir (read-from-minibuffer
-                                   (make-instance 'minibuffer
-                                                  :input-prompt "Target directory:"
-                                                  :completion-function #'next/vcs::projects-roots-completion-filter)))
+                                   (make-minibuffer
+                                    :input-prompt "Target directory:"
+                                    :completion-function #'next/vcs::projects-roots-completion-filter)))
            (next/vcs::clone project-name root-name target-dir clone-uri))))))
 
 (define-command git-clone ()

--- a/source/video-mode.lisp
+++ b/source/video-mode.lisp
@@ -97,9 +97,9 @@ Appends `*download-args' and -o /target/directory/%(title)s.%(ext)s (for youtube
        (funcall next/video:*download-function* url (first next/video::*preferred-download-directories*)))
       (t
        (with-result (target-dir (read-from-minibuffer
-                                 (make-instance 'minibuffer
-                                                :input-prompt "Target directory:"
-                                                :completion-function
-                                                (lambda (input)
-                                                  (file-completion-function input next/video::*preferred-download-directories*)))))
+                                 (make-minibuffer
+                                  :input-prompt "Target directory:"
+                                  :completion-function
+                                  (lambda (input)
+                                    (file-completion-function input next/video::*preferred-download-directories*)))))
          (funcall next/video:*download-function* url target-dir))))))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -192,9 +192,9 @@
 (define-command history-backwards-query ()
   "Query parent URL to navigate back to."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Navigate backwards to:"
-                                      :completion-function (history-backwards-completion-filter))))
+                       (make-minibuffer
+                        :input-prompt "Navigate backwards to:"
+                        :completion-function (history-backwards-completion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -211,9 +211,9 @@
 (define-command history-forwards-query ()
   "Query forward-URL to navigate to."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Navigate forwards to:"
-                                      :completion-function (history-forwards-completion-filter))))
+                       (make-minibuffer
+                        :input-prompt "Navigate forwards to:"
+                        :completion-function (history-forwards-completion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -239,9 +239,9 @@ Otherwise go forward to the only child."
 (define-command history-forwards-all-query ()
   "Query URL to forward to, from all child branches."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Navigate forwards to (all branches):"
-                                      :completion-function (history-forwards-all-completion-filter))))
+                       (make-minibuffer
+                        :input-prompt "Navigate forwards to (all branches):"
+                        :completion-function (history-forwards-all-completion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -258,9 +258,9 @@ Otherwise go forward to the only child."
 (define-command history-all-query ()
   "Query URL to go to, from the whole history."
   (with-result (input (read-from-minibuffer
-                       (make-instance 'minibuffer
-                                      :input-prompt "Navigate to:"
-                                      :completion-function (history-all-completion-filter))))
+                       (make-minibuffer
+                        :input-prompt "Navigate to:"
+                        :completion-function (history-all-completion-filter))))
     (when input
       (set-url-from-history input))))
 
@@ -329,9 +329,9 @@ Otherwise go forward to the only child."
 (define-command paste-from-ring ()
   "Show `*interface*' clipboard ring and paste selected entry."
   (with-result (ring-item (read-from-minibuffer
-                           (make-instance 'minibuffer
-                                          :completion-function (ring-completion-filter
-                                                                (clipboard-ring *interface*)))))
+                           (make-minibuffer
+                            :completion-function (ring-completion-filter
+                                                  (clipboard-ring *interface*)))))
     (%paste :input-text ring-item)))
 
 (define-parenscript %copy ()

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -16,10 +16,10 @@
 (define-command delete-window ()
   "Delete the queried window(s)."
   (with-result (windows (read-from-minibuffer
-                         (make-instance 'minibuffer
-                                        :input-prompt "Delete window(s):"
-                                        :multi-selection-p t
-                                        :completion-function (window-completion-filter))))
+                         (make-minibuffer
+                          :input-prompt "Delete window(s):"
+                          :multi-selection-p t
+                          :completion-function (window-completion-filter))))
     (mapcar #'delete-current-window windows)))
 
 (define-command delete-current-window (&optional (window (rpc-window-active)))


### PR DESCRIPTION
This should mostly fix #419.

Example init.lisp:

```lisp
(defclass my-interface (remote-interface)
  ((download-directory :initform "~/temp")))

(setf *remote-interface-class* 'my-interface)
```

That's it!
Note that we can combine class settings by using multiple inheritance.