### PR TITLE
Clip only first line when getting password from password-store

### DIFF
--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -3,8 +3,20 @@
 (defvar *password-store-program* (executable-find "pass"))
 
 (defmethod list-passwords ((password-interface password-store-interface))
-  (let ((raw-list (directory (format nil "~a/**/*.gpg"
-                                     (password-directory password-interface))))
+  (let ((raw-list (directory
+                   (format nil "~a/**/*.gpg"
+                           (password-directory password-interface))
+                   ;; We truncate the root directory so that the password list
+                   ;; resembles the output from `pass list`. To do so, we
+                   ;; truncate `~/.password-store/` in the pathname strings of
+                   ;; the passwords.
+                   ;;
+                   ;; Special care must be taken for symlinks. Say
+                   ;; `~/.password-store/work` points to `~/work/pass`, would we
+                   ;; follow symlinks, we would not be able to truncate
+                   ;; `~/.password-store/` in `~/work/pass/some/password.gpg`.
+                   ;; Because of this, we don't follow symlinks.
+                   :resolve-symlinks nil))
         (dir-length (length (namestring
                              (truename (password-directory password-interface))))))
     (mapcar #'(lambda (x)

--- a/libraries/password-manager/password-pass.lisp
+++ b/libraries/password-manager/password-pass.lisp
@@ -12,9 +12,17 @@
             raw-list)))
 
 (defmethod clip-password ((password-interface password-store-interface) password-name)
-  (clip-password-string (uiop:run-program (list *password-store-program* "show"
-                                                password-name)
-                                          :output '(:string :stripped t))))
+  (clip-password-string
+   ;; The common way to store secret in password-store is to use the first line
+   ;; for the secret; there's no standard for how to encode anything else.
+   ;; Because there's no support in `password` for having additional fields
+   ;; (e.g. username or email address for autofilling input fields), we'll keep
+   ;; it simple and just return the first line of the password file.
+   (first
+    (cl-ppcre:split #\newline
+                    (uiop:run-program (list *password-store-program* "show"
+                                            password-name)
+                                      :output '(:string :stripped t))))))
 
 (defmethod save-password ((password-interface password-store-interface)
                           password-name password)


### PR DESCRIPTION
Currently all lines from passwords stored in password-store are put into the clipboard buffer. For most purposes only the first line is necessary as this is where the password is stored; any other lines usually contain information related to the secret.

This PR changes `clip-password` for `password-store-interface` to only grab the first line.

I can see that there's currently no handling of errors from `uiop:run-program`, so this would explode on errors from `pass`. `cl-ppcre:split` is fine with a `nil` input, so this PR changes nothing in that regard. I'd be happy to add some error handling around `uiop:run-program`, but I'm not quite sure how to go about it. Do you have any preferences?