### PR TITLE
macOS: Fix icon location in appbundle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ debian:
 .PHONY: app-bundle
 app-bundle: next
 	mkdir -p ./Next.app/Contents/MacOS
-	mkdir -p ./Next.app/Resources
+	mkdir -p ./Next.app/Contents/Resources
 	mv ./next ./Next.app/Contents/MacOS
 	cp -r ./ports/pyqt-webengine/* ./Next.app/Contents/MacOS
 	mv ./Next.app/Contents/MacOS/next-pyqt-webengine.py ./Next.app/Contents/MacOS/next-pyqt-webengine
 	chmod +x ./Next.app/Contents/MacOS/next-pyqt-webengine
 	cp ./assets/Info.plist ./Next.app/Contents
-	cp ./assets/next.icns ./Next.app/Resource
+	cp ./assets/next.icns ./Next.app/Contents/Resources
 
 .PHONY: install-app-bundle
 install-app-bundle:


### PR DESCRIPTION
The icon file was previously being copied to the wrong location in the app
bundle, resulting in the .app having no icon. This PR corrects the location.

I'm pretty sure that somebody pointed this out and posted a patch for in
an issue ticket a while back, which I thought culminated in a PR, but apparently
not.
