### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,7 +59,7 @@ Please see the [[https://next.atlas.engineer/download][downloads]] page for pre-
 systems provide packages for Next:
 
 - Alpine
-- Debian and derivatives (Ubuntu, LinuxMint), for Debian >= 10 (Sid).
+- Debian and derivatives (Ubuntu, LinuxMint), for Debian >= 10 (Buster).
 - [[https://source.atlas.engineer/view/repository/macports-port][MacPorts]]
 - [[https://aur.archlinux.org/packages/next-browser/][Arch Linux AUR]] (and the [[https://aur.archlinux.org/packages/next-browser-git/][-git PKGBUILD]])
 - [[https://nixos.org/nix/][Nix]]: Install with =nix-env --install next=.


### PR DESCRIPTION
As of 2019-07-06, Debian 10 was released as codename "Buster". (It's a bit of a small change but might prevent any confusion pertaining to the Sid name.)