### PR TITLE
Multi buffer search

### DIFF
--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -81,13 +81,9 @@ character-preview-count)))."
     (ps:chain -j-s-o-n (stringify *matches*))))
 
 (define-parenscript focus-match (match)
-  (let* ((rel-identifier
-           (ps:lisp
-            (let ((id (identifier match)))
-              (if (stringp id)
-                  (cadr (str:split ":" id))
-                  id))))
-         (element (ps:chain document (get-element-by-id rel-identifier))))
+  (let ((element
+            (ps:chain
+             document (get-element-by-id (ps:lisp (identifier match))))))
     (ps:chain element (scroll-into-view t))))
 
 (defun handle-match (match)
@@ -101,7 +97,10 @@ character-preview-count)))."
    (buffer :accessor buffer :initarg :buffer)))
 
 (defmethod object-string ((match match))
-  (format nil "~a ...~a..." (identifier match) (body match)))
+  (let ((id (identifier match)))
+    (if (stringp (identifier match))
+        (format nil "~a ...~a...  ~a" id (body match) (title (buffer match)))
+        (format nil "~a ...~a..." id (body match)))))
 
 (defun matches-from-json (matches-json &optional (buffer (current-buffer)) (multi-buffer nil))
   (loop for element in (cl-json:decode-json-from-string matches-json)

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -107,7 +107,11 @@ character-preview-count)))."
   (loop for element in (cl-json:decode-json-from-string matches-json)
         collect (make-instance 'match
                                :identifier (if multi-buffer
-                                               (format nil "~d:~d" (id buffer) (cdr (assoc :identifier element)))
+                                               (format
+                                                nil
+                                                "~d:~d"
+                                                (id buffer)
+                                                (cdr (assoc :identifier element)))
                                                (cdr (assoc :identifier element)))
                                :body (cdr (assoc :body element))
                                :buffer buffer)))
@@ -121,7 +125,9 @@ capture the current-buffer and current-minibuffer in a closure."
           (multi-buffer (if (> (list-length buffers) 1) t nil)))
       (map nil
            (lambda (buffer)
-             (query-buffer :query input :buffer buffer
+             (query-buffer
+              :query input
+              :buffer buffer
               :callback (lambda (result)
                           (let* ((matches (matches-from-json
                                            result buffer multi-buffer)))
@@ -155,32 +161,36 @@ searches over the selected buffer(s)."
                           :input-prompt "Search buffer(s)"
                           :multi-selection-p t
                           :completion-function (buffer-completion-filter))))
-   (search-over-buffers buffers)))
+    (search-over-buffers buffers)))
 
 (defun search-over-buffers (buffers)
   "Add search boxes for a given search string over the
 provided buffers."
   (let* ((num-buffers (list-length buffers))
          (prompt-text
-          (if (> num-buffers 1)
-              (format nil "Search over ~d buffers for (3+ characters)" num-buffers)
-              "Search for (3+ characters)"))
+           (if (> num-buffers 1)
+               (format
+                nil
+                "Search over ~d buffers for (3+ characters)"
+                num-buffers)
+               "Search for (3+ characters)"))
          (minibuffer (make-minibuffer
                       :input-prompt prompt-text
                       :completion-function #'(lambda (input)
                                                (match-completion-function
-                                                input buffers))
+                                                input
+                                                buffers))
                       :history (minibuffer-search-history *interface*)))
          (keymap-scheme (current-keymap-scheme minibuffer))
-         (keymap (getf (keymap-schemes (first (modes minibuffer))) keymap-scheme)))
+         (keymap (getf (keymap-schemes (first (modes minibuffer)))
+                       keymap-scheme)))
     (define-key :keymap keymap "C-s"
                 #'(lambda ()
-                   (when (completions minibuffer)
-                    (focus-match :match (nth (completion-cursor minibuffer)
-                                             (completions minibuffer))))))
+                    (when (completions minibuffer)
+                      (focus-match :match (nth (completion-cursor minibuffer)
+                                               (completions minibuffer))))))
     (with-result (input (read-from-minibuffer minibuffer))
-     (focus-match :match input))))
-
+      (focus-match :match input))))
 
 (define-command remove-search-hints ()
   "Remove all search hints."

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -84,7 +84,8 @@ character-preview-count)))."
   (ps:lisp (when (not (equal (buffer match) (current-buffer)))
              (set-current-buffer (buffer match))))
   ;; TODO: scroll doesn't work properly because it seems it tries to scroll
-  ;; because switching buffer
+  ;; before switching buffer in cases where the buffer should be switched
+  ;; so have to find a way to sync that up
   (let* ((rel-identifier (ps:lisp (cadr (str:split ":" (identifier match)))))
          (element (ps:chain document (get-element-by-id rel-identifier))))
     (ps:chain element (scroll-into-view t))))


### PR DESCRIPTION
So here's a working (but not finished) implementation of search over multiple buffers, as we talked about, @jmercouris.

It uses the same interface as `delete-buffer` for choosing which buffers to do the search on, and then it shows the minibuffer as per the screenshot below where all search results - across all buffers - are presented. You can choose a match with the return key, or "go back and forth" through the matches with "C-s" like with single-buffer search, but with the buffer getting changed as needed. The "N:" prefix to the left of a match's identifier is the index of the buffer.

![multi-buffer-search](https://user-images.githubusercontent.com/58006915/72670853-92956580-3a3a-11ea-9fd3-07f5b97b7be6.png)

So other than the code changes, I also think it's worth discussing how the interface of this feature should actually look. This is just what I came up with, but I can imagine you also have some ideas and/or wishes, @jmercouris, so this is an open invitation to that.

There's also a bug that I'm not yet sure how to deal with. There's a [comment in the code about it here](https://github.com/chrisboeg/next/blob/multi-buffer-search/source/search-buffer.lisp#L86-L88). The deal is that when next is about to focus a search-match, if the match is in another buffer than the currently visible one, it needs to switch to it before it can focus it. The way the code is currently, these two actions are not synced. The focus "attempt" happens and fails before the buffer-switch has happened. I'm not sure what approach to take here, if there is some primitive built in to next that can be used or something like that.

