### PR TITLE
Always update display after toggling mark

### DIFF
--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -895,6 +895,7 @@ Only available if minibuffer `multi-selection-p' is non-nil."
         (match (member candidate marked-completions)
           ((guard n n) (setf marked-completions (delete candidate marked-completions)))
           (_ (push candidate marked-completions)))))
+    (update-display minibuffer)
     (select-next minibuffer)))
 
 (define-command minibuffer-mark-all (&optional (minibuffer (current-minibuffer)))


### PR DESCRIPTION
This fixes the bug I filed at #524 about not being able to choose all buffers with C-Space.

Turned out the problem is that `minibuffer-toggle-mark` relies on `select-next` to `update-display`, but if there is no items left to select, `select-next` doesn't update the display. This patch makes `minibuffer-toggle-mark` itself request an update of the display and thus fixes the bug.