### PR TITLE
Always highlight sometimes follow

### DIFF
--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -228,32 +228,33 @@ identifier for every hinted element."
 (defun update-selection-highlight-hint (&key completions scroll follow
                                           (minibuffer (current-minibuffer))
                                           (buffer (current-buffer)))
-  (flet ((hintp (hint-candidate)
-           (if (typep hint-candidate '(or link-hint button-hint match))
-               hint-candidate
-               nil)))
-    (let ((hint (if completions
+  (let ((hint (flet ((hintp (hint-candidate)
+                       (if (typep hint-candidate
+                                  '(or link-hint button-hint match))
+                           hint-candidate
+                           nil)))
+                (if completions
                     (hintp (first completions))
                     (when minibuffer
                       (let ((hint-candidate (nth (completion-cursor minibuffer)
                                                  (completions minibuffer))))
-                        (hintp hint-candidate))))))
-      (when hint
-        (when (and follow
-                   (slot-exists-p hint 'buffer)
-                   (not (equal (buffer hint) buffer)))
-          (set-current-buffer (buffer hint))
-          (setf buffer (buffer hint)))
-        (if (or
-             ;; type link or button hint - these are single-buffer
-             (not (slot-exists-p hint 'buffer))
-             ;; type match - is multi-buffer
-             (and (slot-exists-p hint 'buffer)
-                  (equal (buffer hint) buffer)))
-            (highlight-selected-hint :buffer buffer
-                                     :link-hint hint
-                                     :scroll scroll)
-            (remove-focus))))))
+                        (hintp hint-candidate)))))))
+    (when hint
+      (when (and follow
+                 (slot-exists-p hint 'buffer)
+                 (not (equal (buffer hint) buffer)))
+        (set-current-buffer (buffer hint))
+        (setf buffer (buffer hint)))
+      (if (or
+           ;; type link or button hint - these are single-buffer
+           (not (slot-exists-p hint 'buffer))
+           ;; type match - is multi-buffer
+           (and (slot-exists-p hint 'buffer)
+                (equal (buffer hint) buffer)))
+          (highlight-selected-hint :buffer buffer
+                                   :link-hint hint
+                                   :scroll scroll)
+          (remove-focus)))))
 
 (define-command follow-hint ()
   "Show a set of element hints, and go to the user inputted one in the

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -133,11 +133,11 @@ identifier for every hinted element."
     (ps:dolist (e old-elements)
       (setf (ps:@ e class-name) "next-hint"))))
 
-(defmacro query-hints (prompt (symbol) &body body)
-  `(let* ((buffer (current-buffer))
-          (minibuffer nil))
+(defun query-hints (prompt func)
+  (let* ((buffer (current-buffer))
+         (minibuffer nil))
      (setf minibuffer (make-minibuffer
-                       :input-prompt ,prompt
+                       :input-prompt prompt
                        :history nil
                        :completion-function
                        (lambda (input) (declare (ignore input)))
@@ -154,13 +154,12 @@ identifier for every hinted element."
                            (setf subsequent-call t)))
                        :cleanup-function
                        (lambda ()
-                         (remove-element-hints :buffer
-                                               (callback-buffer minibuffer)))))
+                         (remove-element-hints :buffer buffer))))
      (with-result (elements-json (add-element-hints))
        (setf (completion-function minibuffer)
              (hint-completion-filter (elements-from-json elements-json)))
-       (with-result (,symbol (read-from-minibuffer minibuffer))
-         ,@body))))
+       (with-result (result (read-from-minibuffer minibuffer))
+         (funcall func result)))))
 
 (defun hint-completion-filter (hints)
   (lambda (input)
@@ -261,25 +260,21 @@ identifier for every hinted element."
 (define-command follow-hint ()
   "Show a set of element hints, and go to the user inputted one in the
 currently active buffer."
-  (query-hints "Go to element:" (selected-element)
-    (%follow-hint selected-element)))
+  (query-hints "Go to element:" '%follow-hint))
 
 (define-command follow-hint-new-buffer ()
   "Show a set of element hints, and open the user inputted one in a new
 buffer (not set to visible active buffer)."
-  (query-hints "Open element in new buffer:" (selected-element)
-    (%follow-hint-new-buffer selected-element)))
+  (query-hints "Open element in new buffer:" '%follow-hint-new-buffer))
 
 (define-command follow-hint-new-buffer-focus ()
   "Show a set of element hints, and open the user inputted one in a new
 visible active buffer."
-  (query-hints "Go to element in new buffer:" (selected-element)
-    (%follow-hint-new-buffer-focus selected-element)))
+  (query-hints "Go to element in new buffer:" '%follow-hint-new-buffer-focus))
 
 (define-command copy-hint-url ()
   "Show a set of element hints, and copy the URL of the user inputted one."
-  (query-hints "Copy element URL:" (selected-element)
-    (%copy-hint-url selected-element)))
+  (query-hints "Copy element URL:" '%copy-hint-url)) 
 
 (define-deprecated-command copy-anchor-url ()
   "Deprecated by `copy-hint-url'."

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -178,11 +178,7 @@ identifier for every hinted element."
 (defclass button-hint (hint) ())
 
 (defclass link-hint (hint)
-  ((url :accessor url :initarg :url)
-   (identifier :accessor identifier :initarg :identifier)
-   (hint :accessor hint :initarg :hint)
-   (body :accessor body :initarg :body
-         :documentation "The body of the anchor tag.")))
+  ((url :accessor url :initarg :url)))
 
 (defmethod object-string ((link-hint link-hint))
   (format nil "~a  ~a  ~a" (hint link-hint) (body link-hint) (url link-hint)))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -227,24 +227,22 @@ identifier for every hinted element."
 
 (defun update-selection-highlight-hint (&key (completions nil) (scroll nil) (follow nil) (minibuffer (current-minibuffer)) (buffer (current-buffer)))
   (defun hintp (hint-candidate)
-    (if (typep hint-candidate
-               '(or link-hint button-hint match))
+    (if (typep hint-candidate '(or link-hint button-hint match))
         hint-candidate
         nil))
   
   (let ((hint (if completions
                   (hintp (first completions))
                   (when minibuffer
-                    (let ((hint-candidate (nth (completion-cursor
-                                                minibuffer)
-                                               (completions
-                                                minibuffer))))
+                    (let ((hint-candidate (nth (completion-cursor minibuffer)
+                                               (completions minibuffer))))
                       (hintp hint-candidate))))))
     (when hint
       (when (and follow
                  (slot-exists-p hint 'buffer)
                  (not (equal (buffer hint) buffer)))
-        (set-current-buffer (buffer hint)))
+        (set-current-buffer (buffer hint))
+        (setf buffer (buffer hint)))
       (if (or (not (slot-exists-p hint 'buffer)) ;; type link-hint or button-hint
               (and (slot-exists-p hint 'buffer) ;; type match, can be multi-buffer
                    (equal (buffer hint) buffer)))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -225,7 +225,9 @@ identifier for every hinted element."
 (defmethod %copy-hint-url ((button-hint button-hint))
   (echo "Can't copy URL from button."))
 
-(defun update-selection-highlight-hint (&key (completions nil) (scroll nil) (follow nil) (minibuffer (current-minibuffer)) (buffer (current-buffer)))
+(defun update-selection-highlight-hint (&key completions scroll follow
+                                          (minibuffer (current-minibuffer))
+                                          (buffer (current-buffer)))
   (defun hintp (hint-candidate)
     (if (typep hint-candidate '(or link-hint button-hint match))
         hint-candidate

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -139,6 +139,8 @@ identifier for every hinted element."
      (setf minibuffer (make-minibuffer
                        :input-prompt ,prompt
                        :history nil
+                       :completion-function
+                       (lambda (input) (declare (ignore input)))
                        :changed-callback
                        (let ((subsequent-call nil))
                          (lambda ()

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -746,7 +746,7 @@ The new webview HTML content it set as the MINIBUFFER's `content'."
   "Select next entry in minibuffer and focus the referencing hint/match
 if there is one such."
   (select-next minibuffer)
-  (update-selection-highlight-hint))
+  (update-selection-highlight-hint :follow t))
 
 (define-command select-previous (&optional (minibuffer (current-minibuffer)))
   "Select previous entry in minibuffer."
@@ -762,7 +762,7 @@ if there is one such."
   "Select previous entry in minibuffer and focus the referencing hint/match
 if there is one such."
   (select-previous minibuffer)
-  (update-selection-highlight-hint))
+  (update-selection-highlight-hint :follow t))
 
 (defun %echo-status (text &key (message (list text))
                           ;; Need to ignore RPC errors in case platform port is

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -746,7 +746,7 @@ The new webview HTML content it set as the MINIBUFFER's `content'."
   "Select next entry in minibuffer and focus the referencing hint/match
 if there is one such."
   (select-next minibuffer)
-  (update-selection-highlight-hint :follow t))
+  (update-selection-highlight-hint :follow t :scroll t))
 
 (define-command select-previous (&optional (minibuffer (current-minibuffer)))
   "Select previous entry in minibuffer."
@@ -762,7 +762,7 @@ if there is one such."
   "Select previous entry in minibuffer and focus the referencing hint/match
 if there is one such."
   (select-previous minibuffer)
-  (update-selection-highlight-hint :follow t))
+  (update-selection-highlight-hint :follow t :scroll t))
 
 (defun %echo-status (text &key (message (list text))
                           ;; Need to ignore RPC errors in case platform port is

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -181,7 +181,14 @@ provided buffers."
                                                 input
                                                 buffers))
                       :changed-callback
-                      (lambda () (update-selection-highlight-hint))
+                      (let ((subsequent-call nil))
+                        (lambda ()
+                          ;; when the minibuffer initially appears, we don't
+                          ;; want update-selection-highlight-hint to scroll
+                          ;; but on subsequent calls, it should scroll
+                          (update-selection-highlight-hint
+                           :scroll subsequent-call)
+                          (setf subsequent-call t)))
                       :cleanup-function (lambda () (remove-focus))
                       :history (minibuffer-search-history *interface*)))
          (keymap-scheme (current-keymap-scheme minibuffer))
@@ -189,10 +196,10 @@ provided buffers."
                        keymap-scheme)))
     (define-key :keymap keymap "C-s"
       #'(lambda ()
-          (update-selection-highlight-hint :follow t)))
+          (update-selection-highlight-hint :follow t :scroll t)))
     (with-result (match (read-from-minibuffer minibuffer))
       (declare (ignore match))
-      (update-selection-highlight-hint))))
+      (update-selection-highlight-hint :follow t :scroll t))))
 
 (define-command remove-search-hints ()
   "Remove all search hints."

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -180,6 +180,8 @@ provided buffers."
                                                (match-completion-function
                                                 input
                                                 buffers))
+                      :changed-callback
+                      (lambda () (update-selection-highlight-hint))
                       :cleanup-function (lambda () (remove-focus))
                       :history (minibuffer-search-history *interface*)))
          (keymap-scheme (current-keymap-scheme minibuffer))
@@ -187,7 +189,7 @@ provided buffers."
                        keymap-scheme)))
     (define-key :keymap keymap "C-s"
       #'(lambda ()
-          (update-selection-highlight-hint)))
+          (update-selection-highlight-hint :follow t)))
     (with-result (match (read-from-minibuffer minibuffer))
       (declare (ignore match))
       (update-selection-highlight-hint))))


### PR DESCRIPTION
This adds the the functionality of always highlighting hints using the new `changed-callback` on the minibuffer, and only following (switching buffer for say a multiple buffer search) with M-n/p.

Initially, it was planned that it shouldn't scroll either with C-n/p, and only scroll and switch buffer with M-n/p, but after testing the feature as such, I thought it was really weird to C-n/p to hints that was out of view, so in this implementation, C-n/p both highlights and scroll, and M-n/p also changes buffer as needed.

What do you think about this, @jmercouris & @impaktor?

There's a bug in this that I'm gonna fix, so it's not ready to get merged yet, but I wanted to hear what you thought about the above. I will request a review when I think it's ready to get merged.