### PR TITLE
documents/MANUAL: Add in-package to keymap example

### DIFF
--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -612,6 +612,8 @@ The user can define key bindings by creating a mode that is loaded before any
 other mode.  In your configuration file:
 
 #+begin_src lisp
+(in-package :next-user)
+
 (defvar *my-keymap* (make-keymap)
   "Keymap for `my-mode'.")
 


### PR DESCRIPTION
Since other config snippets also have the `in-package` header we should also add it to the keymap example.
#537 for reference