### PR TITLE
Add object-display method beside object-string for finer control.

### DIFF
--- a/source/bookmark.lisp
+++ b/source/bookmark.lisp
@@ -56,6 +56,9 @@ SEARCH-URL maybe either be a full URL or a path.  If the latter, the path is
 appended to the URL.")))
 
 (defmethod object-string ((entry bookmark-entry))
+  (url entry))
+
+(defmethod object-display ((entry bookmark-entry))
   (format nil "~a~a  ~a~a"
           (if (str:emptyp (shortcut entry))
               ""

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -12,6 +12,9 @@
           :initform "" :type string)))
 
 (defmethod object-string ((buffer-description buffer-description))
+  (url buffer-description))
+
+(defmethod object-display ((buffer-description buffer-description))
   (format nil "~a  ~a" (url buffer-description) (title buffer-description)))
 
 (defmethod equals ((bd1 buffer-description) (bd2 buffer-description))
@@ -21,6 +24,9 @@ title into accound as it may vary from one load to the next."
   (string= (url bd1) (url bd2)))
 
 (defmethod object-string ((buffer buffer))
+  (url buffer))
+
+(defmethod object-display ((buffer buffer))
   (format nil "~a  ~a" (url buffer) (title buffer)))
 
 (define-command make-buffer (&key (title "default")

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -145,6 +145,9 @@ Otherwise list all commands."
       %%command-list))
 
 (defmethod object-string ((command command))
+  (str:downcase (sym command)))
+
+(defmethod object-display ((command command))
   ;; Use `last-active-window' for speed, or else the minibuffer will stutter
   ;; because of the RPC calls.
   (let* ((buffer (active-buffer (last-active-window *interface*)))

--- a/source/element-hint.lisp
+++ b/source/element-hint.lisp
@@ -194,9 +194,15 @@ identifier for every hinted element."
   ((url :accessor url :initarg :url)))
 
 (defmethod object-string ((link-hint link-hint))
+  (url link-hint))
+
+(defmethod object-display ((link-hint link-hint))
   (format nil "~a  ~a  ~a" (hint link-hint) (body link-hint) (url link-hint)))
 
 (defmethod object-string ((button-hint button-hint))
+  (body button-hint))
+
+(defmethod object-display ((button-hint button-hint))
   (format nil "~a  ~a  Button" (hint button-hint) (body button-hint)))
 
 (defmethod %follow-hint ((link-hint link-hint))

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -38,6 +38,9 @@ Entry for the global history.
 The total number of visit for a given URL is (+ explicit-visits implicit-visits)."))
 
 (defmethod object-string ((entry history-entry))
+  (url entry))
+
+(defmethod object-display ((entry history-entry))
   (format nil "~a  ~a" (url entry) (title entry)))
 
 (defmethod equals ((e1 history-entry) (e2 history-entry))

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -680,7 +680,7 @@ The new webview HTML content it set as the MINIBUFFER's `content'."
                                              ((= i cursor-index) "selected")
                                              ((member completion (marked-completions minibuffer)) "marked")
                                              ((= i (completion-head minibuffer)) "head"))
-                                       (match (object-string completion)
+                                       (match (object-display completion)
                                          ((guard s (not (str:emptyp s))) s)
                                          (_ " ")))))))))
 

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -102,6 +102,9 @@ character-preview-count)))."
    (multi-buffer :accessor multi-buffer :initarg :multi-buffer)))
 
 (defmethod object-string ((match match))
+  (body match))
+
+(defmethod object-display ((match match))
   (let* ((id (identifier match))
          (buffer-id (id (buffer match))))
     (if (multi-buffer match)

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -8,6 +8,10 @@
 (defmethod object-string ((object t))
   (princ-to-string object))
 
+(defmethod object-display ((object t))
+  "Text shown by completion candidates in the minibuffer."
+  (object-string object))
+
 (defmethod object-string ((package package))
   (if (eq (package-name package) (find-package :next))
       ""

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -373,4 +373,4 @@ Otherwise go forward to the only child."
   (echo-dismiss))
 
 (defmethod object-string ((node htree:node))
-  (format nil "~a" (object-string (when node (htree:data node)))))
+  (object-string (when node (htree:data node))))


### PR DESCRIPTION
In particular, this lets the user copy or insert the candidate using a different
string than the display, e.g. only the URL instead of "URL  TITLE" as it used to be.