### PR TITLE
Sort buffer by last access time.

### DIFF
--- a/source/help.lisp
+++ b/source/help.lisp
@@ -190,7 +190,7 @@ The version number is stored in the clipboard."
   "Show the *Messages* buffer."
   (let ((buffer (find-if (lambda (b)
                            (string= "*Messages*" (title b)))
-                         (alexandria:hash-table-values (buffers *interface*)))))
+                         (buffer-list))))
     (unless buffer
       (setf buffer (help-mode :activate t :buffer (make-buffer :title "*Messages*"))))
     (let* ((content

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -207,7 +207,7 @@ It may be MODE-SYMBOL itself."
   "Return first buffer matching MODE-SYMBOL."
   (find-if (lambda (b)
              (find-mode b mode-symbol))
-           (alexandria:hash-table-values (buffers *interface*))))
+           (buffer-list)))
 
 (defmethod keymap ((mode root-mode))
   "Return the keymap of MODE according to its buffer keymap scheme.

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -10,7 +10,7 @@
   "Return list of web buffers.
 I.e. non-special buffers, those with a non-empty URL slot."
   (delete-if (alexandria:compose #'str:emptyp #'url)
-             (alexandria:hash-table-values (buffers *interface*))))
+             (buffer-list)))
 
 (defun session-data ()
   "Return the data that needs to be serialized.

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -280,7 +280,7 @@ Otherwise go forward to the only child."
                         ((guard l l) l))))))
     (let* ((buffer-name (format nil "*History-~a*" (id buffer)))
            (output-buffer (or (find-if (lambda (b) (string= buffer-name (title b)))
-                                       (alexandria:hash-table-values (buffers *interface*)))
+                                       (buffer-list))
                               (help-mode :activate t :buffer (make-buffer :title buffer-name))))
            (history (history (find-submode buffer 'web-mode)))
            (tree (traverse (htree:root history)


### PR DESCRIPTION
This fixes the erratic buffer order when deleting the current buffer or when
switching to the next / previous one.