### PR TITLE
Ensure BYTES-TOTAL returns an integer rather than string.

### DIFF
--- a/libraries/download-manager/engine.lisp
+++ b/libraries/download-manager/engine.lisp
@@ -96,8 +96,9 @@ downloads."
    (format nil "~a.part" (namestring (file download)))))
 
 (defmethod bytes-total ((download download))
-  (gethash "content-length"
-           (header download) 0))
+  (let ((bytes (gethash "content-length"
+                        (header download) 0)))
+    (if (stringp bytes) (parse-integer bytes) bytes)))
 
 (defmethod progress ((download download))
   "Return progress ratio.


### PR DESCRIPTION
This is intended to fix:
,----
|  <INFO> [14:33:16] download-manager native.lisp (fetch download) - Downloading
|   http://www.informatimago.com/articles/cl-types/cl-types-in-sbcl.ps
| to
|   '/home/hugh/Downloads/cl-types-in-sbcl.ps'.
|
| WARNING:
|    Method handler (NEXT::CORE-OBJECT
|                    NEXT::REQUEST-RESOURCE) signaled an error: The value
|                                                                 "108439"
|                                                               is not of type
|                                                                 NUMBER
|                                                               when binding SB-KERNEL::X.
`----
which occurred when selecting the link "cl-types-in-sbcl.ps" on page
http://www.informatimago.com/articles/cl-types/cl-types-in-sbcl.ps.

The expression "(= 0 (download-manager:bytes-total d))" in
DOWNLOAD-REFRESH suggests that the expected return type is integer
rather than string.