### PR TITLE
Gtk abstraction

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -435,7 +435,7 @@ platform port get terminated.  The handlers take no argument.")
    (window-make-hook :accessor window-make-hook
                      :initform (make-hook-window)
                      :type hook-window
-                     :documentation "Hook run after `ipc-window-make'.
+                     :documentation "Hook run after `window-make'.
 The handlers take the window as argument.")
    (buffer-make-hook :accessor buffer-make-hook
                      :initform (make-hook-buffer)
@@ -674,7 +674,7 @@ proceeding."
                                   urls))))
         (unless no-focus
           (if (open-external-link-in-new-window-p *browser*)
-              (let ((window (ipc-window-make *browser*)))
+              (let ((window (window-make *browser*)))
                 (window-set-active-buffer window first-buffer))
               (set-current-buffer first-buffer))))
     (error (c)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -246,7 +246,7 @@ defined in any package and is unique."
 (defmethod initialize-modes ((buffer buffer))
   "Initialize BUFFER modes.
    This must be called after BUFFER has been created on the platform port.
-   See `ipc-buffer-make'."
+   See `buffer-make'."
   (let ((root-mode (make-instance 'root-mode :buffer buffer)))
     (dolist (mode-class (reverse (default-modes buffer)))
       ;; ":activate t" should not be necessary here since (modes buffer) should be
@@ -440,14 +440,14 @@ The handlers take the window as argument.")
    (buffer-make-hook :accessor buffer-make-hook
                      :initform (make-hook-buffer)
                      :type hook-buffer
-                     :documentation "Hook run after `ipc-buffer-make' and before `ipc-buffer-load'.
+                     :documentation "Hook run after `buffer-make' and before `ipc-buffer-load'.
 It is run before `initialize-modes' so that the default mode list can still be
 altered from the hooks.
 The handlers take the buffer as argument.")
    (buffer-before-make-hook :accessor buffer-before-make-hook
                             :initform (make-hook-buffer)
                             :type hook-buffer
-                            :documentation "Hook run before `ipc-buffer-make'.
+                            :documentation "Hook run before `buffer-make'.
 This hook is mostly useful to set the `cookies-path'.
 The buffer web view is not allocated, so it's not possible to run any
 parenscript from this hook.  See `buffer-make-hook' for a hook.
@@ -629,7 +629,7 @@ proceeding."
                                   (alexandria:hash-table-values (windows *browser*)))))
     (next-hooks:run-hook (window-set-active-buffer-hook window) window buffer)
     (if window-with-same-buffer ;; if visible on screen perform swap, otherwise just show
-        (let ((temp-buffer (ipc-buffer-make *browser*))
+        (let ((temp-buffer (buffer-make *browser*))
               (buffer-swap (active-buffer window)))
           (log:debug "Swapping with buffer from existing window.")
           (ipc-window-set-active-buffer window-with-same-buffer temp-buffer)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -199,7 +199,7 @@ return a (possibly new) URL.")
    (buffer-delete-hook :accessor buffer-delete-hook
                        :initform (make-hook-buffer)
                        :type hook-buffer
-                       :documentation "Hook run before `ipc-buffer-delete' takes effect.
+                       :documentation "Hook run before `buffer-delete' takes effect.
 The handlers take the buffer as argument.")))
 
 (defmethod proxy ((buffer buffer))
@@ -635,7 +635,7 @@ proceeding."
           (ipc-window-set-active-buffer window-with-same-buffer temp-buffer)
           (ipc-window-set-active-buffer window buffer)
           (ipc-window-set-active-buffer window-with-same-buffer buffer-swap)
-          (ipc-buffer-delete temp-buffer))
+          (buffer-delete temp-buffer))
         (ipc-window-set-active-buffer window buffer))
     (setf (active-buffer window) buffer)
     (setf (last-access buffer) (local-time:now))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -62,6 +62,26 @@ If DEAD-BUFFER is a dead buffer, recreate its web view and give it a new ID."
     (next-hooks:run-hook (buffer-make-hook browser) buffer)
     buffer))
 
+(declaim (ftype (function (buffer)) buffer-delete))
+(defun buffer-delete (buffer)
+  "This function must be called by the renderer when a window is deleted."
+  (next-hooks:run-hook (buffer-delete-hook buffer) buffer)
+  (let ((parent-window (find-if
+                        (lambda (window) (eql (active-buffer window) buffer))
+                        (alexandria:hash-table-values (windows *browser*))))
+        (replacement-buffer (or (%get-inactive-buffer)
+                                (buffer-make *browser*))))
+    (when parent-window
+      (window-set-active-buffer parent-window replacement-buffer))
+    (ipc-buffer-delete buffer)
+    (remhash (id buffer) (buffers *browser*))
+    (setf (id buffer) "")
+    (add-to-recent-buffers buffer)
+    (match (session-store-function *browser*)
+      ((guard f f)
+       (when *use-session*
+         (funcall f))))))
+
 @export
 (defun buffer-list (&key sort-by-time)
   (let ((buf-list (alexandria:hash-table-values (buffers *browser*))))
@@ -101,11 +121,11 @@ See `make-buffer'."
                           :input-prompt "Delete buffer(s)"
                           :multi-selection-p t
                           :completion-function (buffer-completion-filter))))
-    (mapcar #'ipc-buffer-delete buffers)))
+    (mapcar #'buffer-delete buffers)))
 
 (defun delete-buffers ()
   "Delete all buffers."
-  (mapcar #'ipc-buffer-delete (buffer-list)))
+  (mapcar #'buffer-delete (buffer-list)))
 
 (define-command delete-all-buffers ()
   "Delete all buffers, with confirmation."
@@ -117,7 +137,7 @@ See `make-buffer'."
   "Delete the currently active buffer, and make the next buffer the
 visible buffer. If no other buffers exist, set the url of the current
 buffer to the start page."
-  (ipc-buffer-delete buffer))
+  (buffer-delete buffer))
 
 (define-command delete-other-buffers (&optional (buffer (current-buffer)))
   "Delete all other buffers but `buffer` which if not explicitly set defaults
@@ -126,7 +146,7 @@ to the currently active buffer."
          (buffers-to-delete (remove buffer all-buffers))
          (count (list-length buffers-to-delete)))
     (with-confirm ("Are you sure to delete ~a buffer~p?" count count)
-      (mapcar #'ipc-buffer-delete buffers-to-delete))))
+      (mapcar #'buffer-delete buffers-to-delete))))
 
 ;; WARNING: Don't use this parenscript, use the TITLE buffer slot instead.
 @export

--- a/source/interprocess-communication-gtk.lisp
+++ b/source/interprocess-communication-gtk.lisp
@@ -286,12 +286,7 @@ TODO: Report issue to CL-CFFI-GTK."
 @export
 (defmethod ipc-window-make ((browser gtk-browser))
   "Make a window."
-  (let* ((window (make-instance 'gtk-window)))
-    (setf (gethash (id window) (windows browser)) window)
-    (unless (last-active-window browser)
-      (setf (last-active-window browser) window))
-    (next-hooks:run-hook (window-make-hook browser) window)
-    window))
+  (make-instance 'gtk-window))
 
 @export
 (defmethod ipc-window-to-foreground ((window gtk-window))

--- a/source/interprocess-communication-gtk.lisp
+++ b/source/interprocess-communication-gtk.lisp
@@ -99,10 +99,7 @@
 (defmethod process-destroy ((window gtk-window))
   ;; remove buffer from window to avoid corruption of buffer
   (gtk:gtk-container-remove (box-layout window) (gtk-object (active-buffer window)))
-  (next-hooks:run-hook (window-delete-hook window) window)
-  (remhash (id window) (windows *browser*))
-  (when (zerop (hash-table-count (windows *browser*)))
-    (quit)))
+  (window-delete window))
 
 (defmethod ipc-window-destroy ((window gtk-window))
   (gtk:gtk-widget-destroy (gtk-object window)))
@@ -309,10 +306,7 @@ TODO: Report issue to CL-CFFI-GTK."
 @export
 (defmethod ipc-window-delete ((window gtk-window))
   "Delete a window object and remove it from the hash of windows."
-  (gtk:gtk-container-remove (box-layout window) (gtk-object (active-buffer window)))
-  (gtk:gtk-widget-destroy (gtk-object window))
-  (next-hooks:run-hook (window-delete-hook window) window)
-  (remhash (id window) (windows *browser*)))
+  (gtk:gtk-widget-destroy (gtk-object window)))
 
 @export
 (defmethod ipc-window-active ((browser gtk-browser))

--- a/source/interprocess-communication-gtk.lisp
+++ b/source/interprocess-communication-gtk.lisp
@@ -333,24 +333,7 @@ TODO: Report issue to CL-CFFI-GTK."
 
 @export
 (defmethod ipc-buffer-delete ((buffer gtk-buffer))
-  "Delete BUFFER from `*browser*'.
-   Run BUFFER's `buffer-delete-hook' over BUFFER before deleting it."
-  (next-hooks:run-hook (buffer-delete-hook buffer) buffer)
-  (let ((parent-window (find-if
-                        (lambda (window) (eql (active-buffer window) buffer))
-                        (alexandria:hash-table-values (windows *browser*))))
-        (replacement-buffer (or (%get-inactive-buffer)
-                                (buffer-make *browser*))))
-    (when parent-window
-      (window-set-active-buffer parent-window replacement-buffer))
-    (gtk:gtk-widget-destroy (gtk-object buffer))
-    (remhash (id buffer) (buffers *browser*))
-    (setf (id buffer) "")
-    (add-to-recent-buffers buffer)
-    (match (session-store-function *browser*)
-      ((guard f f)
-       (when *use-session*
-         (funcall f))))))
+  (gtk:gtk-widget-destroy (gtk-object buffer)))
 
 @export
 (defmethod ipc-buffer-load ((buffer gtk-buffer) uri)

--- a/source/recent-buffers.lisp
+++ b/source/recent-buffers.lisp
@@ -24,7 +24,7 @@
                           :completion-function (recent-buffer-completion-filter))))
     (dolist (buffer buffers)
       (ring:delete-match (recent-buffers *browser*) (buffer-match-predicate buffer))
-      (reload-current-buffer (ipc-buffer-make *browser* :dead-buffer buffer))
+      (reload-current-buffer (buffer-make *browser* :dead-buffer buffer))
       (when (and (eq buffer (first buffers))
                  (focus-on-reopened-buffer-p *browser*))
         (set-current-buffer buffer)))))
@@ -32,7 +32,7 @@
 (define-command reopen-last-buffer ()
   "Open a new buffer with the URL of the most recently deleted buffer."
   (if (plusp (ring:item-count (recent-buffers *browser*)))
-      (let ((buffer (ipc-buffer-make *browser*
+      (let ((buffer (buffer-make *browser*
                      :dead-buffer (ring:pop-most-recent (recent-buffers *browser*)))))
         (reload-current-buffer buffer)
         (when (focus-on-reopened-buffer-p *browser*)

--- a/source/session.lisp
+++ b/source/session.lisp
@@ -68,7 +68,7 @@ Currently we store the list of current URLs of all buffers."
              ;; Delete the old buffers?
              ;; (maphash (lambda (id buffer)
              ;;            (declare (ignore id))
-             ;;            (ipc-buffer-delete buffer))
+             ;;            (buffer-delete buffer))
              ;;          buffers)
              ;; Make the new ones.
              ;; TODO: Replace the loop with a function `make-buffer-from-history' in web-mode?

--- a/source/start.lisp
+++ b/source/start.lisp
@@ -180,7 +180,7 @@ EXPR must contain one single Lisp form. Use `progn' if needed."
    suitable as a `browser' `startup-function'."
   (when urls
     (open-urls urls))
-  (let ((window (ipc-window-make *browser*))
+  (let ((window (window-make *browser*))
         (buffer (help)))
     (window-set-active-buffer window buffer))
   (match (session-restore-function *browser*)

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -13,6 +13,15 @@
     (lambda (input)
       (fuzzy-match input windows))))
 
+(declaim (ftype (function (window)) window-delete))
+(defun window-delete (window)
+  "This function must be called by the renderer when a window is deleted."
+  (ipc-window-delete window)
+  (next-hooks:run-hook (window-delete-hook window) window)
+  (remhash (id window) (windows *browser*))
+  (when (zerop (hash-table-count (windows *browser*)))
+    (quit)))
+
 (define-command delete-window ()
   "Delete the queried window(s)."
   (with-result (windows (read-from-minibuffer

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -13,6 +13,16 @@
     (lambda (input)
       (fuzzy-match input windows))))
 
+(declaim (ftype (function (browser)) window-make))
+(defun window-make (browser)
+  "This function must be called by the renderer when a window is deleted."
+  (let* ((window (ipc-window-make browser)))
+    (setf (gethash (id window) (windows browser)) window)
+    (unless (last-active-window browser)
+      (setf (last-active-window browser) window))
+    (next-hooks:run-hook (window-make-hook browser) window)
+    window))
+
 (declaim (ftype (function (window)) window-delete))
 (defun window-delete (window)
   "This function must be called by the renderer when a window is deleted."


### PR DESCRIPTION
I've extracted the high-level code from the GTK renderer so that it can be factorer with other renderers (e.g. running hooks).

This saves some 50 lines of code in GTK, which is important considering we are saving them from all future renderers.