### PR TITLE
session.lisp: prevent restoring nil histories.

### DIFF
--- a/source/session.lisp
+++ b/source/session.lisp
@@ -61,6 +61,7 @@ Currently we store the list of current URLs of all buffers."
           ((list version buffer-histories)
            (unless (string= version +version+)
              (log:warn "Session version ~s differs from current version ~s" version +version+))
+           (setf buffer-histories (delete-if-not #'htree:current buffer-histories))
            (when buffer-histories
              (log:info "Restoring ~a"
                        (mapcar #'object-string (mapcar (alexandria:compose #'htree:data #'htree:current)


### PR DESCRIPTION
observe the `history-tree:data` being passed `nil` when running e.g. `next "https://google.nl"