### PR TITLE
Noscript-mode only blocks javascript markup

### DIFF
--- a/source/noscript-mode.lisp
+++ b/source/noscript-mode.lisp
@@ -8,8 +8,8 @@
     ((destructor
       :initform
       (lambda (mode)
-        (ipc-buffer-enable-javascript (buffer mode) t)))
+        (ipc-buffer-enable-javascript-markup (buffer mode) t)))
      (constructor
       :initform
       (lambda (mode)
-        (ipc-buffer-enable-javascript (buffer mode) nil)))))
+        (ipc-buffer-enable-javascript-markup (buffer mode) nil)))))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -374,6 +374,12 @@
         value))
 
 @export
+(defmethod ipc-buffer-enable-javascript-markup ((buffer gtk-buffer) value)
+  (setf (webkit:webkit-settings-enable-javascript-markup
+         (webkit:webkit-web-view-get-settings (gtk-object buffer)))
+        value))
+
+@export
 (defmethod ipc-buffer-set-proxy ((buffer gtk-buffer) &optional proxy-uri (ignore-hosts (list nil)))
   "Redirect network connections of BUFFER to proxy server PROXY-URI.
    Hosts in IGNORE-HOSTS (a list of strings) ignore the proxy.


### PR DESCRIPTION
@Ambrevar I figured out this issue and fixed it, only to then find out at commit-time that you already did so in a revision of next from 9 months ago. I shamelessly stole your commit message. 

*NOTE*: This should only be merged after joachifm/cl-webkit#38 is upstreamed (and subsequently `build-scripts/guix.scm` should be updated to refer to that version of cl-webkit)

Also fixes #595 