### PR TITLE
Keymap scheme

### DIFF
--- a/documents/CHANGELOG.org
+++ b/documents/CHANGELOG.org
@@ -48,6 +48,11 @@ MAJOR.MINOR.PATCH, we increment the:
 
 - Keymaps must be named, e.g. ~(keymap:make-keymap "my-map")~.
 
+- Modes =keymap-schemes= must now be set with either =keymap:make-scheme= or
+  =define-scheme=.  Schemes are now first-class objects.  Defaults schemes
+  =cua=, =emacs=, =vi-normal= and =vi-insert= are in the =scheme= package.  Thus
+  it's enough to complete over =scheme:= to list them all.
+
 ** DONE 1.5.0
 - Add =certificate-whitelist-mode=.  (Thanks to Alexander Egorenkov.)
 

--- a/libraries/keymap/package.lisp
+++ b/libraries/keymap/package.lisp
@@ -60,8 +60,11 @@
    empty-modifiers
 
    ;; scheme
-   scheme
+   scheme-name
    make-scheme-name
+   scheme-name-p
+   scheme
+   scheme-p
    define-scheme
    get-keymap
    make-scheme)

--- a/libraries/keymap/package.lisp
+++ b/libraries/keymap/package.lisp
@@ -62,7 +62,9 @@
    ;; scheme
    scheme
    make-scheme-name
-   define-scheme)
+   define-scheme
+   get-keymap
+   make-scheme)
   (:documentation "
 The workflow goes as follows:
 - Make a keymap with `make-keymap'.

--- a/libraries/keymap/package.lisp
+++ b/libraries/keymap/package.lisp
@@ -57,7 +57,12 @@
    make-key-required-arg
    empty-keyspec
    empty-value
-   empty-modifiers)
+   empty-modifiers
+
+   ;; scheme
+   scheme
+   make-scheme-name
+   define-scheme)
   (:documentation "
 The workflow goes as follows:
 - Make a keymap with `make-keymap'.
@@ -72,3 +77,14 @@ Some globals can be tweaked to customize the library to your needs:
 - `*print-shortcuts*': Print modifiers using their short form instead of the
   full name, e.g. \"C\" instead of \"control\".
 - `*default-bound-type*': The allowed type for bound values; default to T (everything)."))
+
+(defpackage :scheme
+  (:use :common-lisp)
+  (:import-from :keymap :make-scheme-name )
+  (:export
+   :cua
+   :emacs
+   :vi-normal
+   :vi-insert)
+  (:documentation "Package holding the list of well-known scheme names.
+We use a dedicated package so that scheme names can easily be listed and completed."))

--- a/libraries/keymap/scheme-names.lisp
+++ b/libraries/keymap/scheme-names.lisp
@@ -1,0 +1,6 @@
+(in-package :scheme)
+
+(defvar cua (make-scheme-name "cua"))
+(defvar emacs (make-scheme-name "emacs" cua))
+(defvar vi-normal (make-scheme-name "vi-normal" cua emacs))
+(defvar vi-insert (make-scheme-name "vi-insert" cua))

--- a/libraries/keymap/scheme.lisp
+++ b/libraries/keymap/scheme.lisp
@@ -81,3 +81,21 @@ The scheme keymaps are named \"my-mode-cua-map\" and \"my-mode-emacs-map\"."
                     :do (check-type keyspecs (or keyspecs-type list))))
     `(progn
        (define-scheme* ,name-prefix ,name ,bindings ,@more-name+bindings-pairs))))
+
+(declaim (ftype (function (scheme-name scheme) (or keymap null)) get-keymap))
+(defun get-keymap (name scheme)
+  "Return keymap corresponding to NAME in SCHEME.
+Return nil if not found."
+  (gethash name scheme))
+
+(declaim (ftype (function (scheme-name keymap &rest list) scheme) make-scheme))
+(defun make-scheme (name keymap &rest more-name+keymaps-pairs)
+  "Return a new scheme associating NAME to KEYMAP.
+With MORE-NAME+KEYMAPS-PAIRS, include those names and keymaps as well.  This is
+useful in complement to `define-scheme' to make a scheme with pre-existing
+keymaps."
+  (let ((scheme (make-hash-table :test #'equal))
+        (name+keymaps-pairs (append (list name keymap) more-name+keymaps-pairs)))
+    (loop :for (name keymaps) :on name+keymaps-pairs :by #'cddr
+          :do (setf (gethash name scheme) keymap))
+    scheme))

--- a/libraries/keymap/scheme.lisp
+++ b/libraries/keymap/scheme.lisp
@@ -1,0 +1,81 @@
+(in-package :keymap)
+
+(defclass scheme-name ()
+  ((name :initarg :name
+         :accessor name
+         :type string
+         :documentation "A scheme name.")
+   (parents :initarg :parents
+            :accessor parents
+            :initform '()
+            :type list-of-scheme-names
+            :documentation "The list of parents.  When a scheme is defined, the
+keymap parents are automatically set to the keymaps corresponding to the given
+schemes.  See `define-scheme'.")))
+
+(declaim (ftype (function (string &rest scheme-name) scheme-name) make-scheme-name))
+(defun make-scheme-name (name &rest parents)
+  (coerce
+   (make-instance 'scheme-name
+                  :name name
+                  :parents parents)
+   'scheme-name))
+
+(defun scheme-name-p (name)
+  (typep name 'scheme-name))
+
+(declaim (ftype (function (hash-table) boolean) scheme-p))
+(defun scheme-p (scheme)
+  (loop :for name :being :the hash-keys :in scheme :using (:hash-value keymap)
+        :always (and (scheme-name-p name)
+                     (keymap-p keymap))))
+
+(deftype scheme ()
+  `(and hash-table
+        (satisfies scheme-p)))
+
+(declaim (ftype (function (scheme-name list &rest list) scheme) define-scheme*))
+(defun define-scheme* (name bindings &rest more-name+bindings-pairs)
+  "Define scheme.
+See `define-scheme' for the user-facing function."
+  (let ((name+bindings-pairs (append (list name bindings) more-name+bindings-pairs))
+        (scheme (make-hash-table :test #'equal)))
+    (loop :for (name _ . rest) :on name+bindings-pairs :by #'cddr
+          :do (setf (gethash name scheme) (make-keymap (format nil "~s-map" name))))
+    ;; Set parents now that all keymaps exist.
+    (maphash (lambda (name keymap)
+               (setf (parents keymap)
+                     (mapcar (lambda (parent-name) (gethash parent-name scheme))
+                             (parents name))))
+             scheme)
+    ;; Set bindings.
+    (loop :for (name bindings . rest) :on name+bindings-pairs :by #'cddr
+          :for keymap = (gethash name scheme)
+          :do (loop :for (keyspecs bound-value . rest) :on bindings :by #'cddr
+                    :do (define-key* keymap keyspecs bound-value))) ; TODO: Can we use define-key?
+    scheme))
+
+;; We need a macro here for the same reason `define-key' is a macro.
+(defmacro define-scheme (name bindings &rest more-name+bindings-pairs)
+  "Return a scheme, a hash table with scheme NAMEs as key and their BINDINGS as value.
+
+Example:
+
+  (define-scheme
+    scheme:cua (list
+                \"C-c\" 'copy
+                \"C-v\" 'paste)
+
+    scheme:emacs '(\"M-w\" copy
+                   \"M-y\" paste))
+
+In the above, `scheme:cua' is a parent of `scheme:cua'; thus the Emacs keymap
+will have the CUA keymap as parent."
+  (let ((name+bindings-pairs (append (list name bindings) more-name+bindings-pairs)))
+    (loop :for (_ quoted-bindings . rest) :on name+bindings-pairs :by #'cddr
+          :for bindings = (rest quoted-bindings)
+          :do (check-type bindings list)
+          :do (loop :for (keyspecs _ . rest) :on bindings :by #'cddr
+                    :do (check-type keyspecs (or keyspecs-type list))))
+    `(progn
+       (define-scheme* ,name ,bindings ,@more-name+bindings-pairs))))

--- a/libraries/keymap/tests/scheme-tests.lisp
+++ b/libraries/keymap/tests/scheme-tests.lisp
@@ -3,21 +3,23 @@
 (prove:plan nil)
 
 (prove:subtest "Make scheme"
-  (let* ((scheme (keymap:define-scheme
+  (let* ((scheme (keymap:define-scheme "test"
                      scheme:cua '("C-c" copy
                                   "C-v" paste)))
-         (keymap (keymap:make-keymap "cua-map")))
+         (keymap (keymap:make-keymap "test-cua-map")))
     (keymap:define-key keymap "C-c" 'copy)
     (keymap:define-key keymap "C-v" 'paste)
     (prove:is (fset:convert 'fset:map (keymap:keymap->map (gethash scheme:cua scheme)))
               (fset:convert 'fset:map (keymap:keymap->map keymap))
-              :test #'fset:equal?)))
+              :test #'fset:equal?)
+    (prove:is (keymap:name (gethash scheme:cua scheme))
+              (keymap:name keymap))))
 
 (prove:subtest "Make scheme with LIST"
-  (let* ((scheme (keymap:define-scheme
+  (let* ((scheme (keymap:define-scheme "test"
                      scheme:cua (list "C-c" 'copy
                                       "C-v" 'paste)))
-         (keymap (keymap:make-keymap "cua-map")))
+         (keymap (keymap:make-keymap "test-cua-map")))
     (keymap:define-key keymap
       "C-c" 'copy
       "C-v" 'paste)
@@ -26,13 +28,13 @@
               :test #'fset:equal?)))
 
 (prove:subtest "Make scheme with multiple names"
-  (let* ((scheme (keymap:define-scheme
+  (let* ((scheme (keymap:define-scheme "test"
                      scheme:cua (list "C-c" 'copy
                                       "C-v" 'paste)
                    scheme:emacs (list "M-w" 'copy
                                       "M-y" 'paste)))
-         (cua-keymap (keymap:make-keymap "cua-map"))
-         (emacs-keymap (keymap:make-keymap "emacs-map")))
+         (cua-keymap (keymap:make-keymap "test-cua-map"))
+         (emacs-keymap (keymap:make-keymap "test-emacs-map")))
     (keymap:define-key cua-keymap
       "C-c" 'copy
       "C-v" 'paste)
@@ -47,13 +49,13 @@
               :test #'fset:equal?)))
 
 (prove:subtest "Test inheritance"
-  (let* ((scheme (keymap:define-scheme
+  (let* ((scheme (keymap:define-scheme "test"
                      scheme:cua (list "C-c" 'copy
                                       "C-v" 'paste)
                    scheme:emacs (list "M-w" 'copy
                                       "M-y" 'paste)))
-         (cua-keymap (keymap:make-keymap "cua-map"))
-         (emacs-keymap (keymap:make-keymap "emacs-map")))
+         (cua-keymap (keymap:make-keymap "test-cua-map"))
+         (emacs-keymap (keymap:make-keymap "test-emacs-map")))
     (keymap:define-key cua-keymap
       "C-c" 'copy
       "C-v" 'paste)

--- a/libraries/keymap/tests/scheme-tests.lisp
+++ b/libraries/keymap/tests/scheme-tests.lisp
@@ -1,0 +1,71 @@
+(in-package :cl-user)
+
+(prove:plan nil)
+
+(prove:subtest "Make scheme"
+  (let* ((scheme (keymap:define-scheme
+                     scheme:cua '("C-c" copy
+                                  "C-v" paste)))
+         (keymap (keymap:make-keymap "cua-map")))
+    (keymap:define-key keymap "C-c" 'copy)
+    (keymap:define-key keymap "C-v" 'paste)
+    (prove:is (fset:convert 'fset:map (keymap:keymap->map (gethash scheme:cua scheme)))
+              (fset:convert 'fset:map (keymap:keymap->map keymap))
+              :test #'fset:equal?)))
+
+(prove:subtest "Make scheme with LIST"
+  (let* ((scheme (keymap:define-scheme
+                     scheme:cua (list "C-c" 'copy
+                                      "C-v" 'paste)))
+         (keymap (keymap:make-keymap "cua-map")))
+    (keymap:define-key keymap
+      "C-c" 'copy
+      "C-v" 'paste)
+    (prove:is (fset:convert 'fset:map (keymap:keymap->map (gethash scheme:cua scheme)))
+              (fset:convert 'fset:map (keymap:keymap->map keymap))
+              :test #'fset:equal?)))
+
+(prove:subtest "Make scheme with multiple names"
+  (let* ((scheme (keymap:define-scheme
+                     scheme:cua (list "C-c" 'copy
+                                      "C-v" 'paste)
+                   scheme:emacs (list "M-w" 'copy
+                                      "M-y" 'paste)))
+         (cua-keymap (keymap:make-keymap "cua-map"))
+         (emacs-keymap (keymap:make-keymap "emacs-map")))
+    (keymap:define-key cua-keymap
+      "C-c" 'copy
+      "C-v" 'paste)
+    (keymap:define-key emacs-keymap
+      "M-w" 'copy
+      "M-y" 'paste)
+    (prove:is (fset:convert 'fset:map (keymap:keymap->map (gethash scheme:cua scheme)))
+              (fset:convert 'fset:map (keymap:keymap->map cua-keymap))
+              :test #'fset:equal?)
+    (prove:is (fset:convert 'fset:map (keymap:keymap->map (gethash scheme:emacs scheme)))
+              (fset:convert 'fset:map (keymap:keymap->map emacs-keymap))
+              :test #'fset:equal?)))
+
+(prove:subtest "Test inheritance"
+  (let* ((scheme (keymap:define-scheme
+                     scheme:cua (list "C-c" 'copy
+                                      "C-v" 'paste)
+                   scheme:emacs (list "M-w" 'copy
+                                      "M-y" 'paste)))
+         (cua-keymap (keymap:make-keymap "cua-map"))
+         (emacs-keymap (keymap:make-keymap "emacs-map")))
+    (keymap:define-key cua-keymap
+      "C-c" 'copy
+      "C-v" 'paste)
+    (keymap:define-key emacs-keymap
+      "M-w" 'copy
+      "M-y" 'paste)
+    (prove:is (list (gethash scheme:cua scheme))
+              (keymap:parents (gethash scheme:emacs scheme)))))
+
+;; (prove:subtest "Make scheme with type errors" ; TODO: How do we test macro-expansion-time error?
+;;   (prove:is-error (keymap:define-scheme
+;;                       scheme:cua (list "C-" 'copy))
+;;                   'type-error))
+
+(prove:finalize)

--- a/libraries/keymap/types.lisp
+++ b/libraries/keymap/types.lisp
@@ -23,3 +23,4 @@ Example:
 (define-list-type 'string)
 (define-list-type 'key)
 (define-list-type 'keymap)
+(define-list-type 'scheme-name)

--- a/next.asd
+++ b/next.asd
@@ -183,12 +183,15 @@
                 :components ((:file "package")
                              (:file "types")
                              (:file "conditions")
-                             (:file "keymap")))))
+                             (:file "keymap")
+                             (:file "scheme")
+                             (:file "scheme-names")))))
 
 (asdf:defsystem next/keymap/tests
   :defsystem-depends-on (prove-asdf)
   :depends-on (alexandria fset prove next/keymap)
   :components ((:module source/tests :pathname "libraries/keymap/tests/"
-                :components ((:test-file "tests"))))
+                :components ((:test-file "tests")
+                             (:test-file "scheme-tests"))))
   :perform (asdf:test-op (op c) (uiop:symbol-call
                                  :prove-asdf 'run-test-system c)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -117,7 +117,7 @@ instantiate on buffer creation, unless specified.")
    (keymap-scheme-name
     :accessor keymap-scheme-name
     :initarg :keymap-scheme-name
-    :initform scheme:emacs
+    :initform scheme:cua
     :type keymap:scheme
     :documentation "The keymap scheme that will be used
 for all modes in the current buffer.")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -122,7 +122,7 @@ instantiate on buffer creation, unless specified.")
 for all modes in the current buffer.")
    (override-map :accessor override-map
                  :initarg :override-map
-                 :initform (let ((map (keymap:make-keymap "overide-map")))
+                 :initform (let ((map (make-keymap "overide-map")))
                              (define-key map
                                "M-x" #'execute-command)
                              map)

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -114,10 +114,11 @@ not associated with a web view) have an empty ID.")
                   :type trivial-types:proper-list
                   :documentation "The list of symbols of class to
 instantiate on buffer creation, unless specified.")
-   (current-keymap-scheme ; TODO: Name keymap-scheme instead?
-    :accessor current-keymap-scheme
-    :initarg :current-keymap-scheme
-    :initform :emacs
+   (keymap-scheme-name
+    :accessor keymap-scheme-name
+    :initarg :keymap-scheme-name
+    :initform scheme:emacs
+    :type keymap:scheme
     :documentation "The keymap scheme that will be used
 for all modes in the current buffer.")
    (override-map :accessor override-map

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -197,11 +197,13 @@ complete against a search engine."
   "Minibuffer mode for setting the URL of a buffer."
   ((keymap-schemes
     :initform
-    (let ((map (make-keymap "set-url-map")))
-      (define-key map
-        "tab" #'insert-candidate-or-search-engine)
-      (list :emacs map
-            :vi-normal map)))))
+    (define-scheme "set-url"
+      scheme:emacs
+      (list
+       "tab" #'insert-candidate-or-search-engine)
+      scheme:vi-normal
+      (list
+       "tab" #'insert-candidate-or-search-engine)))))
 
 (define-command set-url-current-buffer (&key new-buffer-p)
   "Set the URL for the current buffer, completing with history."

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -197,7 +197,7 @@ complete against a search engine."
   "Minibuffer mode for setting the URL of a buffer."
   ((keymap-schemes
     :initform
-    (let ((map (keymap:make-keymap "set-url-map")))
+    (let ((map (make-keymap "set-url-map")))
       (define-key map
         "tab" #'insert-candidate-or-search-engine)
       (list :emacs map

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -152,10 +152,10 @@ Otherwise list all commands."
   ;; Use `last-active-window' for speed, or else the minibuffer will stutter
   ;; because of the RPC calls.
   (let* ((buffer (active-buffer (last-active-window *browser*)))
-         (scheme (keymap-scheme-name buffer))
+         (scheme-name (keymap-scheme-name buffer))
          (bindings '()))
     (loop for mode in (modes buffer)
-          for scheme-keymap = (gethash scheme (keymap-schemes mode))
+          for scheme-keymap = (keymap:get-keymap scheme-name (keymap-schemes mode))
           when scheme-keymap
             do (setf bindings (keymap:binding-keys (command-function command) scheme-keymap))
           when (not (null bindings))

--- a/source/command.lisp
+++ b/source/command.lisp
@@ -152,10 +152,10 @@ Otherwise list all commands."
   ;; Use `last-active-window' for speed, or else the minibuffer will stutter
   ;; because of the RPC calls.
   (let* ((buffer (active-buffer (last-active-window *browser*)))
-         (scheme (current-keymap-scheme buffer))
+         (scheme (keymap-scheme-name buffer))
          (bindings '()))
     (loop for mode in (modes buffer)
-          for scheme-keymap = (getf (keymap-schemes mode) scheme)
+          for scheme-keymap = (gethash scheme (keymap-schemes mode))
           when scheme-keymap
             do (setf bindings (keymap:binding-keys (command-function command) scheme-keymap))
           when (not (null bindings))

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -96,8 +96,8 @@ on the minibuffer. Specialize keybindings on this mode. See the
 command `open-file'."
     ((keymap-schemes
       :initform
-      (let ((emacs-map (keymap:make-keymap "file-manager-emacs-map"))
-            (vi-map (keymap:make-keymap "file-manager-vi-map")))
+      (let ((emacs-map (make-keymap "file-manager-emacs-map"))
+            (vi-map (make-keymap "file-manager-vi-map")))
 
         (define-key emacs-map
           "M-left" #'display-parent-directory

--- a/source/file-manager-mode.lisp
+++ b/source/file-manager-mode.lisp
@@ -1,6 +1,6 @@
 (uiop:define-package :next/file-manager-mode
   (:use :common-lisp :trivia :next)
-  (:import-from #:keymap #:define-key)
+  (:import-from #:keymap #:define-key #:define-scheme)
   (:export
    :open-file-function
    :*open-file-function*
@@ -91,26 +91,23 @@ with the file."
   "Function triggered to open files.")
 
 (define-mode file-manager-mode (minibuffer-mode)
-    "Mode to open any file from the filesystem with fuzzy completion
+  "Mode to open any file from the filesystem with fuzzy completion
 on the minibuffer. Specialize keybindings on this mode. See the
 command `open-file'."
-    ((keymap-schemes
-      :initform
-      (let ((emacs-map (make-keymap "file-manager-emacs-map"))
-            (vi-map (make-keymap "file-manager-vi-map")))
+  ((keymap-schemes
+    :initform
+    (define-scheme "file-manager"
+      scheme:emacs
+      (list
+       "M-left" #'display-parent-directory
+       "C-l" #'display-parent-directory
+       "C-j" #'enter-directory
+       "M-right" #'enter-directory)
 
-        (define-key emacs-map
-          "M-left" #'display-parent-directory
-          "C-l" #'display-parent-directory
-          "C-j" #'enter-directory
-          "M-right" #'enter-directory)
-
-        (define-key vi-map
-          "M-right" #'enter-directory
-          "M-left" #'display-parent-directory)
-
-        (list :emacs emacs-map
-              :vi-normal vi-map)))))
+      scheme:vi-normal
+      (list
+       "M-right" #'enter-directory
+       "M-left" #'display-parent-directory)))))
 
 @export
 (defun open-file-from-directory-completion-filter (input &optional (directory *current-directory*))

--- a/source/global.lisp
+++ b/source/global.lisp
@@ -24,9 +24,6 @@ It can be initialized with
 It's possible to run multiple interfaces of Next at the same time.  You can
 let-bind *browser* to temporarily switch interface.")
 
-;; Only allow function in `define-key':
-(setf keymap:*default-bound-type* '(or keymap:keymap function))
-
 (declaim (type next-hooks:hook-void *after-init-hook*))
 @export
 (defvar *after-init-hook* (make-instance 'next-hooks:hook-void)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -7,8 +7,8 @@
     "Mode for displaying documentation."
     ((keymap-schemes
       :initform
-      (let ((emacs-map (keymap:make-keymap "help-emacs-map"))
-            (vi-map (keymap:make-keymap "help-vi-map")))
+      (let ((emacs-map (make-keymap "help-emacs-map"))
+            (vi-map (make-keymap "help-vi-map")))
         (define-key emacs-map
           "C-p" #'scroll-up
           "C-n" #'scroll-down)

--- a/source/help.lisp
+++ b/source/help.lisp
@@ -4,19 +4,18 @@
 
 ;; TODO: Move to a separate package like other modes?
 (define-mode help-mode ()
-    "Mode for displaying documentation."
-    ((keymap-schemes
-      :initform
-      (let ((emacs-map (make-keymap "help-emacs-map"))
-            (vi-map (make-keymap "help-vi-map")))
-        (define-key emacs-map
-          "C-p" #'scroll-up
-          "C-n" #'scroll-down)
-        (define-key vi-map
-          "k" #'scroll-up
-          "j" #'scroll-down)
-        (list :emacs emacs-map
-              :vi-normal vi-map)))))
+  "Mode for displaying documentation."
+  ((keymap-schemes
+    :initform
+    (define-scheme "help"
+      scheme:emacs
+      (list
+       "C-p" #'scroll-up
+       "C-n" #'scroll-down)
+      scheme:vi-normal
+      (list
+       "k" #'scroll-up
+       "j" #'scroll-down)))))
 
 (defun package-symbols (p)
   (let (l) (do-symbols (s p l)

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -1,6 +1,4 @@
-;; TODO: Move scheme support to library?
 ;; TODO: Use CUA scheme by default.
-;; TODO: Make Emacs / VI schemes inherit from each other.
 ;; TODO: which-key: List all bindings with some prefix.
 ;; TODO: Make sure it's easy enough to set global bindings.
 

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -6,6 +6,17 @@
 
 (in-package :next)
 
+(declaim (ftype (function (string &rest keymap:keymap)
+                          keymap:keymap)
+                make-keymap))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (export '(make-keymap)))
+(defun make-keymap (name &rest parents)
+  "Like `keymap:make-keymap' but only allow binding functions."
+  (let ((keymap (apply #'keymap:make-keymap name parents)))
+    (setf (keymap:bound-type keymap) '(or keymap:keymap function))
+    keymap))
+
 (defun current-keymaps (&optional (window (ipc-window-active *browser*)))
   "Return the list of `keymap' for the current buffer, ordered by priority."
   (let ((buffer (active-buffer window)))

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -1,4 +1,3 @@
-;; TODO: Use CUA scheme by default.
 ;; TODO: which-key: List all bindings with some prefix.
 ;; TODO: Make sure it's easy enough to set global bindings.
 

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -18,7 +18,7 @@
   "Mode for the minibuffer."
   ((keymap-schemes
     :initform
-    (let ((map (keymap:make-keymap "minibuffer-map")))
+    (let ((map (make-keymap "minibuffer-map")))
       (define-key map
         "hyphen" #'self-insert
         "space" #'self-insert

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -18,7 +18,8 @@
   "Mode for the minibuffer."
   ((keymap-schemes
     :initform
-    (define-scheme "minibuffer" scheme:emacs
+    (define-scheme "minibuffer"
+      scheme:cua
       (list
        "hyphen" #'self-insert
        "space" #'self-insert

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -18,55 +18,53 @@
   "Mode for the minibuffer."
   ((keymap-schemes
     :initform
-    (let ((map (make-keymap "minibuffer-map")))
-      (define-key map
-        "hyphen" #'self-insert
-        "space" #'self-insert
-        "C-f" #'cursor-forwards
-        "M-f" #'cursor-forwards-word
-        "C-right" #'cursor-forwards-word
-        "C-b" #'cursor-backwards
-        "M-b" #'cursor-backwards-word
-        "C-left" #'cursor-backwards-word
-        "M-d" #'delete-forwards-word
-        "M-backspace" #'delete-backwards-word
-        "right" #'cursor-forwards
-        "left" #'cursor-backwards
-        "C-d" #'delete-forwards
-        "delete" #'delete-forwards
-        "backspace" #'delete-backwards
-        "C-a" #'cursor-beginning
-        "home" #'cursor-beginning
-        "C-e" #'cursor-end
-        "end" #'cursor-end
-        "C-k" #'kill-line
-        "return" #'return-input
-        "C-return" #'return-immediate
-        "C-g" #'cancel-input
-        "escape" #'cancel-input
-        "C-n" #'select-next
-        "C-p" #'select-previous
-        "M-n" #'select-next-follow
-        "M-p" #'select-previous-follow
-        "button4" #'select-previous
-        "button5" #'select-next
-        "down" #'select-next
-        "up" #'select-previous
-        "C-v" #'minibuffer-paste
-        "C-y" #'minibuffer-paste
-        "C-w" #'copy-candidate
-        "tab" #'insert-candidate
-        "M-h" #'minibuffer-history
-        "C-space" #'minibuffer-toggle-mark
-        "M-a" #'minibuffer-mark-all
-        "M-u" #'minibuffer-unmark-all)
-      (list :emacs map
-            ;; TODO: We could have VI bindings for the minibuffer too.
-            ;; But we need to make sure it's optional + to have an indicator
-            ;; for the mode.  This requires either a change of cursor or a
-            ;; echo area separate from the minibuffer.
-            :vi-normal map
-            :vi-insert map)))))
+    (define-scheme "minibuffer" scheme:emacs
+      (list
+       "hyphen" #'self-insert
+       "space" #'self-insert
+       "C-f" #'cursor-forwards
+       "M-f" #'cursor-forwards-word
+       "C-right" #'cursor-forwards-word
+       "C-b" #'cursor-backwards
+       "M-b" #'cursor-backwards-word
+       "C-left" #'cursor-backwards-word
+       "M-d" #'delete-forwards-word
+       "M-backspace" #'delete-backwards-word
+       "right" #'cursor-forwards
+       "left" #'cursor-backwards
+       "C-d" #'delete-forwards
+       "delete" #'delete-forwards
+       "backspace" #'delete-backwards
+       "C-a" #'cursor-beginning
+       "home" #'cursor-beginning
+       "C-e" #'cursor-end
+       "end" #'cursor-end
+       "C-k" #'kill-line
+       "return" #'return-input
+       "C-return" #'return-immediate
+       "C-g" #'cancel-input
+       "escape" #'cancel-input
+       "C-n" #'select-next
+       "C-p" #'select-previous
+       "M-n" #'select-next-follow
+       "M-p" #'select-previous-follow
+       "button4" #'select-previous
+       "button5" #'select-next
+       "down" #'select-next
+       "up" #'select-previous
+       "C-v" #'minibuffer-paste
+       "C-y" #'minibuffer-paste
+       "C-w" #'copy-candidate
+       "tab" #'insert-candidate
+       "M-h" #'minibuffer-history
+       "C-space" #'minibuffer-toggle-mark
+       "M-a" #'minibuffer-mark-all
+       "M-u" #'minibuffer-unmark-all))
+    ;; TODO: We could have VI bindings for the minibuffer too.
+    ;; But we need to make sure it's optional + to have an indicator
+    ;; for the mode.  This requires either a change of cursor or a
+    ;; echo area separate from the minibuffer.
+    )))
 
 @export
 @export-accessors

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -109,72 +109,68 @@ It is run before the destructor.")
                  :documentation "This hook is run when disabling the mode.
 It takes the mode as argument.
 It is run before the destructor.")
-   (keymap-schemes :accessor keymap-schemes :initarg :keymap-schemes :type list
-                   :initform
-                   (let ((vi-map (make-keymap "root-vi-map"))
-                         (emacs-map (make-keymap "root-emacs-map")))
-                     (define-key emacs-map
-                       "C-x C-c" #'quit
-                       "C-[" #'switch-buffer-previous
-                       "C-]" #'switch-buffer-next
-                       "C-x b" #'switch-buffer
-                       "C-x k" #'delete-buffer ; Emacs' default behaviour is to query.
-                       "C-x C-k" #'delete-current-buffer
-                       "C-x left" #'switch-buffer-previous
-                       "C-x right" #'switch-buffer-next
-                       "C-pageup" #'switch-buffer-previous
-                       "C-pagedown" #'switch-buffer-next
-                       "C-l" #'set-url-current-buffer
-                       "M-l" #'set-url-new-buffer
-                       "C-m k" #'bookmark-delete
-                       "C-t" #'make-buffer-focus
-                       "C-m u" #'bookmark-url
-                       ;; TODO: Rename to inspect-variable?  Wouldn't describe-variable be more familiar?
-                       "C-h v" #'variable-inspect
-                       "C-h c" #'command-inspect
-                       "C-h k" #'key-inspect
-                       "C-h b" #'bindings-inspect
-                       "C-o" #'load-file
-                       "C-h s" #'start-swank
-                       "M-x" #'execute-command
-                       "M-:" #'command-evaluate
-                       "C-x 5 2" #'make-window
-                       "C-x 5 0" #'delete-current-window
-                       "C-x 5 1" #'delete-window
-                       "C-/" #'reopen-buffer
-                       "C-x C-f" #'open-file)
-
-                     (define-key vi-map
-                       "Z Z" #'quit
-                       "[" #'switch-buffer-previous
-                       "]" #'switch-buffer-next
-                       "C-pageup" #'switch-buffer-previous
-                       "C-pagedown" #'switch-buffer-next
-                       "g b" #'switch-buffer
-                       "d" #'delete-buffer
-                       "D" #'delete-current-buffer
-                       "B" #'make-buffer-focus
-                       "o" #'set-url-current-buffer
-                       "O" #'set-url-new-buffer
-                       "m u" #'bookmark-url
-                       "m d" #'bookmark-delete
-                       "C-o" #'load-file
-                       "C-h v" #'variable-inspect
-                       "C-h c" #'command-inspect
-                       "C-h k" #'command-inspect
-                       "C-h b" #'bindings-inspect
-                       "C-h s" #'start-swank
-                       ":" #'execute-command
-                       "M-:" #'command-evaluate
-                       "W" #'make-window
-                       "C-w C-w" #'make-window
-                       "C-w q" #'delete-current-window
-                       "C-w C-q" #'delete-window
-                       "u" #'reopen-buffer
-                       "C-x C-f" #'open-file)
-
-                     (list :emacs emacs-map
-                           :vi-normal vi-map)))))
+   (keymap-schemes :accessor keymap-schemes :initarg :keymap-schemes :type keymap:scheme
+                   :initform (define-scheme "root"
+                               scheme:emacs
+                               (list
+                                "C-x C-c" #'quit
+                                "C-[" #'switch-buffer-previous
+                                "C-]" #'switch-buffer-next
+                                "C-x b" #'switch-buffer
+                                "C-x k" #'delete-buffer ; Emacs' default behaviour is to query.
+                                "C-x C-k" #'delete-current-buffer
+                                "C-x left" #'switch-buffer-previous
+                                "C-x right" #'switch-buffer-next
+                                "C-pageup" #'switch-buffer-previous
+                                "C-pagedown" #'switch-buffer-next
+                                "C-l" #'set-url-current-buffer
+                                "M-l" #'set-url-new-buffer
+                                "C-m k" #'bookmark-delete
+                                "C-t" #'make-buffer-focus
+                                "C-m u" #'bookmark-url
+                                ;; TODO: Rename to inspect-variable?  Wouldn't describe-variable be more familiar?
+                                "C-h v" #'variable-inspect
+                                "C-h c" #'command-inspect
+                                "C-h k" #'key-inspect
+                                "C-h b" #'bindings-inspect
+                                "C-o" #'load-file
+                                "C-h s" #'start-swank
+                                "M-x" #'execute-command
+                                "M-:" #'command-evaluate
+                                "C-x 5 2" #'make-window
+                                "C-x 5 0" #'delete-current-window
+                                "C-x 5 1" #'delete-window
+                                "C-/" #'reopen-buffer
+                                "C-x C-f" #'open-file)
+                               scheme:vi-normal
+                               (list
+                                "Z Z" #'quit
+                                "[" #'switch-buffer-previous
+                                "]" #'switch-buffer-next
+                                "C-pageup" #'switch-buffer-previous
+                                "C-pagedown" #'switch-buffer-next
+                                "g b" #'switch-buffer
+                                "d" #'delete-buffer
+                                "D" #'delete-current-buffer
+                                "B" #'make-buffer-focus
+                                "o" #'set-url-current-buffer
+                                "O" #'set-url-new-buffer
+                                "m u" #'bookmark-url
+                                "m d" #'bookmark-delete
+                                "C-o" #'load-file
+                                "C-h v" #'variable-inspect
+                                "C-h c" #'command-inspect
+                                "C-h k" #'command-inspect
+                                "C-h b" #'bindings-inspect
+                                "C-h s" #'start-swank
+                                ":" #'execute-command
+                                "M-:" #'command-evaluate
+                                "W" #'make-window
+                                "C-w C-w" #'make-window
+                                "C-w q" #'delete-current-window
+                                "C-w C-q" #'delete-window
+                                "u" #'reopen-buffer
+                                "C-x C-f" #'open-file)))))
 
 (defmethod object-string ((mode root-mode))
   (symbol-name (class-name (class-of mode))))
@@ -216,8 +212,8 @@ It may be MODE-SYMBOL itself."
 (defmethod keymap ((mode root-mode))
   "Return the keymap of MODE according to its buffer keymap scheme.
 If there is no corresponding keymap, return nil."
-  (getf (keymap-schemes mode)
-        (current-keymap-scheme (buffer mode))))
+  (gethash (keymap-scheme-name (buffer mode))
+           (keymap-schemes mode)))
 
 (defmethod did-commit-navigation ((mode root-mode) url)
   url)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -212,8 +212,8 @@ It may be MODE-SYMBOL itself."
 (defmethod keymap ((mode root-mode))
   "Return the keymap of MODE according to its buffer keymap scheme.
 If there is no corresponding keymap, return nil."
-  (gethash (keymap-scheme-name (buffer mode))
-           (keymap-schemes mode)))
+  (keymap:get-keymap (keymap-scheme-name (buffer mode))
+                     (keymap-schemes mode)))
 
 (defmethod did-commit-navigation ((mode root-mode) url)
   url)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -111,6 +111,41 @@ It takes the mode as argument.
 It is run before the destructor.")
    (keymap-schemes :accessor keymap-schemes :initarg :keymap-schemes :type keymap:scheme
                    :initform (define-scheme "root"
+                               scheme:cua
+                               (list
+                                "C-q" #'quit
+                                "C-[" #'switch-buffer-previous
+                                "C-]" #'switch-buffer-next
+                                "C-x b" #'switch-buffer
+                                "C-x k" #'delete-buffer ; Emacs' default behaviour is to query.
+                                "C-x C-k" #'delete-current-buffer
+                                "C-x left" #'switch-buffer-previous
+                                "C-x right" #'switch-buffer-next
+                                "C-pageup" #'switch-buffer-previous
+                                "C-pagedown" #'switch-buffer-next
+                                "C-l" #'set-url-current-buffer
+                                "M-l" #'set-url-new-buffer
+                                "C-m k" #'bookmark-delete
+                                "C-t" #'make-buffer-focus
+                                "C-m u" #'bookmark-url
+                                ;; TODO: Rename to inspect-variable?  Wouldn't describe-variable be more familiar?
+                                "f1 v" #'variable-inspect
+                                "f1 c" #'command-inspect
+                                "f1 k" #'key-inspect
+                                "f1 b" #'bindings-inspect
+                                "C-h v" #'variable-inspect
+                                "C-h c" #'command-inspect
+                                "C-h k" #'key-inspect
+                                "C-h b" #'bindings-inspect
+                                "C-o" #'load-file
+                                "C-h s" #'start-swank
+                                "M-x" #'execute-command
+                                "M-:" #'command-evaluate
+                                "C-x 5 2" #'make-window
+                                "C-x 5 0" #'delete-current-window
+                                "C-x 5 1" #'delete-window
+                                "C-/" #'reopen-buffer
+                                "C-x C-f" #'open-file)
                                scheme:emacs
                                (list
                                 "C-x C-c" #'quit

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -111,8 +111,8 @@ It takes the mode as argument.
 It is run before the destructor.")
    (keymap-schemes :accessor keymap-schemes :initarg :keymap-schemes :type list
                    :initform
-                   (let ((vi-map (keymap:make-keymap "root-vi-map"))
-                         (emacs-map (keymap:make-keymap "root-emacs-map")))
+                   (let ((vi-map (make-keymap "root-vi-map"))
+                         (emacs-map (make-keymap "root-emacs-map")))
                      (define-key emacs-map
                        "C-x C-c" #'quit
                        "C-[" #'switch-buffer-previous

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -6,11 +6,11 @@
 ;; exports are spread around.  `uiop:define-package' does not have this problem.
 (uiop:define-package next
   (:use :common-lisp :trivia :annot.class)
-  (:import-from #:keymap #:define-key))
+  (:import-from #:keymap #:define-key #:define-scheme))
 
 (uiop:define-package next-user
   (:use :common-lisp :trivia :next)
-  (:import-from #:keymap #:define-key)
+  (:import-from #:keymap #:define-key #:define-scheme)
   (:documentation "
 Package left for the user to fiddgle with.
 It's recommended to use this package in the Next configuration file, instead of

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -193,9 +193,9 @@ provided buffers."
                           (setf subsequent-call t)))
                       :cleanup-function (lambda () (remove-focus))
                       :history (minibuffer-search-history *browser*)))
-         (keymap-scheme (current-keymap-scheme minibuffer))
-         (keymap (getf (keymap-schemes (first (modes minibuffer)))
-                       keymap-scheme)))
+         (keymap-scheme (keymap-scheme-name minibuffer))
+         (keymap (gethash keymap-scheme
+                          (keymap-schemes (first (modes minibuffer))))))
     (define-key keymap
       "C-s" #'(lambda ()
                 (update-selection-highlight-hint :follow t :scroll t)))

--- a/source/search-buffer.lisp
+++ b/source/search-buffer.lisp
@@ -194,8 +194,8 @@ provided buffers."
                       :cleanup-function (lambda () (remove-focus))
                       :history (minibuffer-search-history *browser*)))
          (keymap-scheme (keymap-scheme-name minibuffer))
-         (keymap (gethash keymap-scheme
-                          (keymap-schemes (first (modes minibuffer))))))
+         (keymap (keymap:get-keymap keymap-scheme
+                                    (keymap-schemes (first (modes minibuffer))))))
     (define-key keymap
       "C-s" #'(lambda ()
                 (update-selection-highlight-hint :follow t :scroll t)))

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -1,6 +1,6 @@
 (uiop:define-package :next/vi-mode
   (:use :common-lisp :trivia :next)
-  (:import-from #:keymap #:define-key)
+  (:import-from #:keymap #:define-key #:define-scheme)
   (:documentation "VI-style bindings."))
 (in-package :next/vi-mode)
 
@@ -8,24 +8,24 @@
   "Enable VI-style modal bindings (normal mode)"
   ((keymap-schemes
     :initform
-    (let ((map (make-keymap "vi-normal-map")))
-      (define-key map
+    (define-scheme "vi"
+      scheme:vi-normal
+      (list
         "i" #'vi-insert-mode
-        "button1" #'vi-button1)
-      (list :vi-normal map)))
+        "button1" #'vi-button1)))
    (destructor
     :initform
     (lambda (mode)
-      (setf (current-keymap-scheme (buffer mode))
-            (get-default 'buffer 'current-keymap-scheme))
+      (setf (keymap-scheme-name (buffer mode))
+            (get-default 'buffer 'keymap-scheme-name))
       (setf (forward-input-events-p (buffer mode))
-            (get-default 'buffer 'current-keymap-scheme))))
+            (get-default 'buffer 'keymap-scheme-name))))
    (constructor
     :initform
     (lambda (mode)
       (let ((active-buffer (buffer mode)))
         (vi-insert-mode :activate nil :buffer active-buffer)
-        (setf (current-keymap-scheme active-buffer) :vi-normal)
+        (setf (keymap-scheme-name active-buffer) scheme:vi-normal)
         (setf (forward-input-events-p active-buffer) nil))))))
 
 ;; TODO: Move ESCAPE binding to the override map?
@@ -33,25 +33,25 @@
   "Enable VI-style modal bindings (insert mode)"
   ((keymap-schemes
     :initform
-    (let ((map (make-keymap "vi-insert-map")))
-      (define-key map
-        ;; TODO: Forwarding C-v crashes cl-webkit.  See
-        ;; https://github.com/atlas-engineer/next/issues/593#issuecomment-599051350
-        "C-v" #'next/web-mode:paste
-        "escape" #'vi-normal-mode
-        "button1" #'vi-button1)
-      (list :vi-insert map)))
+    (define-scheme "vi"
+      scheme:vi-insert
+      (list
+       ;; TODO: Forwarding C-v crashes cl-webkit.  See
+       ;; https://github.com/atlas-engineer/next/issues/593#issuecomment-599051350
+       "C-v" #'next/web-mode:paste
+       "escape" #'vi-normal-mode
+       "button1" #'vi-button1)))
    (destructor
     :initform
     (lambda (mode)
-      (setf (current-keymap-scheme (buffer mode))
-            (get-default 'buffer 'current-keymap-scheme))))
+      (setf (keymap-scheme-name (buffer mode))
+            (get-default 'buffer 'keymap-scheme-name))))
    (constructor
     :initform
     (lambda (mode)
       (let ((active-buffer (buffer mode)))
         (vi-normal-mode :activate nil :buffer active-buffer)
-        (setf (current-keymap-scheme active-buffer) :vi-insert))))))
+        (setf (keymap-scheme-name active-buffer) scheme:vi-insert))))))
 
 (define-parenscript %clicked-in-input? ()
   (ps:chain document active-element tag-name))

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -8,7 +8,7 @@
   "Enable VI-style modal bindings (normal mode)"
   ((keymap-schemes
     :initform
-    (let ((map (keymap:make-keymap "vi-normal-map")))
+    (let ((map (make-keymap "vi-normal-map")))
       (define-key map
         "i" #'vi-insert-mode
         "button1" #'vi-button1)
@@ -33,7 +33,7 @@
   "Enable VI-style modal bindings (insert mode)"
   ((keymap-schemes
     :initform
-    (let ((map (keymap:make-keymap "vi-insert-map")))
+    (let ((map (make-keymap "vi-insert-map")))
       (define-key map
         ;; TODO: Forwarding C-v crashes cl-webkit.  See
         ;; https://github.com/atlas-engineer/next/issues/593#issuecomment-599051350

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -18,8 +18,8 @@
             :initform (htree:make))
    (keymap-schemes
     :initform
-    (let ((emacs-map (keymap:make-keymap "web-emacs-map"))
-          (vi-map (keymap:make-keymap "web-vi-map")))
+    (let ((emacs-map (make-keymap "web-emacs-map"))
+          (vi-map (make-keymap "web-vi-map")))
       (define-key emacs-map
         "C-M-f" #'history-forwards-all-query
         "C-M-b" #'history-all-query

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -19,6 +19,70 @@
    (keymap-schemes
     :initform
     (define-scheme "web"
+      scheme:cua
+      (list
+       "C-M-f" #'history-forwards-all-query
+       "C-M-b" #'history-all-query
+       "C-f" #'history-forwards-query
+       "C-b" #'history-backwards-query
+       "M-right" #'history-forwards
+       "M-left" #'history-backwards
+       "C-g" #'follow-hint
+       "M-g" #'follow-hint-new-buffer-focus
+       "C-u M-g" #'follow-hint-new-buffer
+       "C-x C-w" #'copy-hint-url
+       "C-v" #'paste
+       "C-c" #'copy
+       "button9" #'history-forwards
+       "button8" #'history-backwards
+       "C-p" #'scroll-up
+       "C-n" #'scroll-down
+       "C-x C-=" #'zoom-in-page
+       "C-x s-+" #'zoom-in-page
+       "C-x C-s-+" #'zoom-in-page
+       "C-x C-+" #'zoom-in-page
+       "C-x +" #'zoom-in-page
+       "C-x C-hyphen" #'zoom-out-page
+       "C-x hyphen" #'zoom-out-page
+       "C-x C-0" #'unzoom-page
+       "C-x 0" #'unzoom-page
+       "C-r" #'reload-current-buffer
+       "C-R" #'reload-buffer
+       "C-m o" #'set-url-from-bookmark
+       "C-m s" #'bookmark-current-page
+       "C-m C-s" #'bookmark-page
+       "C-m g" #'bookmark-hint
+       "C-f" #'search-buffer
+       "M-f" #'remove-search-hints
+       "C-." #'jump-to-heading
+       "M-s->" #'scroll-to-bottom
+       "M-s-<" #'scroll-to-top
+       "M->" #'scroll-to-bottom
+       "M-<" #'scroll-to-top
+       ;; "C-v" #'scroll-page-down
+       "M-v" #'scroll-page-up
+       "C-w" #'copy-url
+       "M-w" #'copy-title
+       ;; Leave SPACE unbound so that the paltform port decides wether to
+       ;; insert of scroll.
+       "s-space" #'scroll-page-up
+
+       ;; keypad:
+       "pageup" #'scroll-page-up
+       "pagedown" #'scroll-page-down
+       "pageend" #'scroll-to-bottom
+       "pagehome" #'scroll-to-top
+       ;; keypad, gtk:
+       "keypadleft" #'scroll-left
+       "keypaddown" #'scroll-down
+       "keypadup" #'scroll-up
+       "keypadright" #'scroll-right
+       "keypadend" #'scroll-to-bottom
+       "keypadhome" #'scroll-to-top
+       "keypadnext" #'scroll-page-down
+       "keypadpageup" #'scroll-page-up
+       "keypadprior" #'scroll-page-up)
+
       scheme:emacs
       (list
        "C-M-f" #'history-forwards-all-query
@@ -31,8 +95,8 @@
        "M-g" #'follow-hint-new-buffer-focus
        "C-u M-g" #'follow-hint-new-buffer
        "C-x C-w" #'copy-hint-url
-       "C-v" #'paste
-       "C-c" #'copy
+       "M-y" #'paste
+       "C-y" #'copy
        "button9" #'history-forwards
        "button8" #'history-backwards
        "C-p" #'scroll-up

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -1,6 +1,6 @@
 (uiop:define-package :next/web-mode
   (:use :common-lisp :trivia :next :annot.class)
-  (:import-from #:keymap #:define-key)
+  (:import-from #:keymap #:define-key #:define-scheme)
   (:documentation "Mode for web pages"))
 (in-package :next/web-mode)
 
@@ -18,131 +18,130 @@
             :initform (htree:make))
    (keymap-schemes
     :initform
-    (let ((emacs-map (make-keymap "web-emacs-map"))
-          (vi-map (make-keymap "web-vi-map")))
-      (define-key emacs-map
-        "C-M-f" #'history-forwards-all-query
-        "C-M-b" #'history-all-query
-        "M-f" #'history-forwards-query
-        "M-b" #'history-backwards-query
-        "C-f" #'history-forwards
-        "C-b" #'history-backwards
-        "C-g" #'follow-hint
-        "M-g" #'follow-hint-new-buffer-focus
-        "C-u M-g" #'follow-hint-new-buffer
-        "C-x C-w" #'copy-hint-url
-        "C-v" #'paste
-        "C-c" #'copy
-        "button9" #'history-forwards
-        "button8" #'history-backwards
-        "C-p" #'scroll-up
-        "C-n" #'scroll-down
-        "C-x C-=" #'zoom-in-page
-        "C-x s-+" #'zoom-in-page
-        "C-x C-s-+" #'zoom-in-page
-        "C-x C-+" #'zoom-in-page
-        "C-x +" #'zoom-in-page
-        "C-x C-hyphen" #'zoom-out-page
-        "C-x hyphen" #'zoom-out-page
-        "C-x C-0" #'unzoom-page
-        "C-x 0" #'unzoom-page
-        "C-r" #'reload-current-buffer
-        "C-R" #'reload-buffer
-        "C-m o" #'set-url-from-bookmark
-        "C-m s" #'bookmark-current-page
-        "C-m C-s" #'bookmark-page
-        "C-m g" #'bookmark-hint
-        "C-s s" #'search-buffer
-        "C-s k" #'remove-search-hints
-        "C-." #'jump-to-heading
-        "M-s->" #'scroll-to-bottom
-        "M-s-<" #'scroll-to-top
-        "M->" #'scroll-to-bottom
-        "M-<" #'scroll-to-top
-        ;; "C-v" #'scroll-page-down
-        "M-v" #'scroll-page-up
-        "C-w" #'copy-url
-        "M-w" #'copy-title
-        ;; Leave SPACE unbound so that the paltform port decides wether to
-        ;; insert of scroll.
-        "s-space" #'scroll-page-up
+    (define-scheme "web"
+      scheme:emacs
+      (list
+       "C-M-f" #'history-forwards-all-query
+       "C-M-b" #'history-all-query
+       "M-f" #'history-forwards-query
+       "M-b" #'history-backwards-query
+       "C-f" #'history-forwards
+       "C-b" #'history-backwards
+       "C-g" #'follow-hint
+       "M-g" #'follow-hint-new-buffer-focus
+       "C-u M-g" #'follow-hint-new-buffer
+       "C-x C-w" #'copy-hint-url
+       "C-v" #'paste
+       "C-c" #'copy
+       "button9" #'history-forwards
+       "button8" #'history-backwards
+       "C-p" #'scroll-up
+       "C-n" #'scroll-down
+       "C-x C-=" #'zoom-in-page
+       "C-x s-+" #'zoom-in-page
+       "C-x C-s-+" #'zoom-in-page
+       "C-x C-+" #'zoom-in-page
+       "C-x +" #'zoom-in-page
+       "C-x C-hyphen" #'zoom-out-page
+       "C-x hyphen" #'zoom-out-page
+       "C-x C-0" #'unzoom-page
+       "C-x 0" #'unzoom-page
+       "C-r" #'reload-current-buffer
+       "C-R" #'reload-buffer
+       "C-m o" #'set-url-from-bookmark
+       "C-m s" #'bookmark-current-page
+       "C-m C-s" #'bookmark-page
+       "C-m g" #'bookmark-hint
+       "C-s s" #'search-buffer
+       "C-s k" #'remove-search-hints
+       "C-." #'jump-to-heading
+       "M-s->" #'scroll-to-bottom
+       "M-s-<" #'scroll-to-top
+       "M->" #'scroll-to-bottom
+       "M-<" #'scroll-to-top
+       ;; "C-v" #'scroll-page-down
+       "M-v" #'scroll-page-up
+       "C-w" #'copy-url
+       "M-w" #'copy-title
+       ;; Leave SPACE unbound so that the paltform port decides wether to
+       ;; insert of scroll.
+       "s-space" #'scroll-page-up
 
-        ;; keypad:
-        "pageup" #'scroll-page-up
-        "pagedown" #'scroll-page-down
-        "pageend" #'scroll-to-bottom
-        "pagehome" #'scroll-to-top
-        ;; keypad, gtk:
-        "keypadleft" #'scroll-left
-        "keypaddown" #'scroll-down
-        "keypadup" #'scroll-up
-        "keypadright" #'scroll-right
-        "keypadend" #'scroll-to-bottom
-        "keypadhome" #'scroll-to-top
-        "keypadnext" #'scroll-page-down
-        "keypadpageup" #'scroll-page-up
-        "keypadprior" #'scroll-page-up)
+       ;; keypad:
+       "pageup" #'scroll-page-up
+       "pagedown" #'scroll-page-down
+       "pageend" #'scroll-to-bottom
+       "pagehome" #'scroll-to-top
+       ;; keypad, gtk:
+       "keypadleft" #'scroll-left
+       "keypaddown" #'scroll-down
+       "keypadup" #'scroll-up
+       "keypadright" #'scroll-right
+       "keypadend" #'scroll-to-bottom
+       "keypadhome" #'scroll-to-top
+       "keypadnext" #'scroll-page-down
+       "keypadpageup" #'scroll-page-up
+       "keypadprior" #'scroll-page-up)
 
-      (define-key vi-map
-        "H" #'history-backwards
-        "L" #'history-forwards
-        "M-h" #'history-backwards-query
-        "M-l" #'history-forwards-query
-        "M-H" #'history-all-query
-        "M-L" #'history-forwards-all-query
-        "f" #'follow-hint
-        "F" #'follow-hint-new-buffer-focus
-        "; f" #'follow-hint-new-buffer
-        "button9" #'history-forwards
-        "button8" #'history-backwards
+      scheme:vi-normal
+      (list
+       "H" #'history-backwards
+       "L" #'history-forwards
+       "M-h" #'history-backwards-query
+       "M-l" #'history-forwards-query
+       "M-H" #'history-all-query
+       "M-L" #'history-forwards-all-query
+       "f" #'follow-hint
+       "F" #'follow-hint-new-buffer-focus
+       "; f" #'follow-hint-new-buffer
+       "button9" #'history-forwards
+       "button8" #'history-backwards
 
-        "h" #'scroll-left
-        "j" #'scroll-down
-        "k" #'scroll-up
-        "l" #'scroll-right
-        "left" #'scroll-left
-        "down" #'scroll-down
-        "up" #'scroll-up
-        "right" #'scroll-right
-        ;; keypad:
-        "pageend" #'scroll-to-bottom
-        "pagehome" #'scroll-to-top
-        ;; keypad, gtk:
-        "keypadleft" #'scroll-left
-        "keypaddown" #'scroll-down
-        "keypadup" #'scroll-up
-        "keypadright" #'scroll-right
-        "keypadend" #'scroll-to-bottom
-        "keypadhome" #'scroll-to-top
-        "keypadnext" #'scroll-page-down
-        "keypadpageup" #'scroll-page-up
-        "keypadprior" #'scroll-page-up
+       "h" #'scroll-left
+       "j" #'scroll-down
+       "k" #'scroll-up
+       "l" #'scroll-right
+       "left" #'scroll-left
+       "down" #'scroll-down
+       "up" #'scroll-up
+       "right" #'scroll-right
+       ;; keypad:
+       "pageend" #'scroll-to-bottom
+       "pagehome" #'scroll-to-top
+       ;; keypad, gtk:
+       "keypadleft" #'scroll-left
+       "keypaddown" #'scroll-down
+       "keypadup" #'scroll-up
+       "keypadright" #'scroll-right
+       "keypadend" #'scroll-to-bottom
+       "keypadhome" #'scroll-to-top
+       "keypadnext" #'scroll-page-down
+       "keypadpageup" #'scroll-page-up
+       "keypadprior" #'scroll-page-up
 
-        "C-v" #'paste
-        "z i" #'zoom-in-page
-        "z o" #'zoom-out-page
-        "z z" #'unzoom-page
-        "R" #'reload-current-buffer
-        "r" #'reload-buffer
-        "m o" #'set-url-from-bookmark
-        "m m" #'bookmark-page
-        "m M" #'bookmark-current-page
-        "m f" #'bookmark-hint
-        "y u" #'copy-url
-        "y t" #'copy-title
-        "g h" #'jump-to-heading ; REVIEW: VI binding?  "gh" is probably good enough.
-        "/" #'search-buffer
-        "?" #'remove-search-hints
-        "G" #'scroll-to-bottom
-        "g g" #'scroll-to-top
-        "C-f" #'scroll-page-down
-        "C-b" #'scroll-page-up
-        "space" #'scroll-page-down
-        "s-space" #'scroll-page-up
-        "pageup" #'scroll-page-up
-        "pagedown" #'scroll-page-down)
-      (list :emacs emacs-map
-            :vi-normal vi-map))))
+       "C-v" #'paste
+       "z i" #'zoom-in-page
+       "z o" #'zoom-out-page
+       "z z" #'unzoom-page
+       "R" #'reload-current-buffer
+       "r" #'reload-buffer
+       "m o" #'set-url-from-bookmark
+       "m m" #'bookmark-page
+       "m M" #'bookmark-current-page
+       "m f" #'bookmark-hint
+       "y u" #'copy-url
+       "y t" #'copy-title
+       "g h" #'jump-to-heading ; REVIEW: VI binding?  "gh" is probably good enough.
+       "/" #'search-buffer
+       "?" #'remove-search-hints
+       "G" #'scroll-to-bottom
+       "g g" #'scroll-to-top
+       "C-f" #'scroll-page-down
+       "C-b" #'scroll-page-up
+       "space" #'scroll-page-down
+       "s-space" #'scroll-page-up
+       "pageup" #'scroll-page-up
+       "pagedown" #'scroll-page-down))))
   ;; Init.
   ;; TODO: Do we need to set the default URL?  Maybe not.
   ;; (set-url (default-new-buffer-url (buffer %mode))


### PR DESCRIPTION
Previously our keymap scheme system had a few drawbacks:

- Declaring bindings for modes was a bit verbose and repetitive.
- Scheme names were keywords, which means they were prone to typo errors.
- No type checking.

This is now fixed thanks to a few helper functions, e.g. `define-scheme`, `make-scheme`, `get-keymap`.

Plus we now get an extra convenience: the default scheme names are all in the `scheme` package, which means we can complete on `scheme:` to list them all.  And avoid typos.
Anyways, there is compile-time type-checking now.