### PR TITLE
Echo status

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -20,10 +20,10 @@
    (active-buffer :accessor active-buffer :initform nil)
    (active-minibuffers :accessor active-minibuffers :initform nil
                        :documentation "The stack of currently active minibuffers.")
-   (status-buffer-height :accessor status-buffer-height :initform 26
+   (status-buffer-height :accessor status-buffer-height :initform 16
                          :type integer
                          :documentation "The height of the status buffer in pixels.")
-   (message-buffer-height :accessor message-buffer-height :initform 26
+   (message-buffer-height :accessor message-buffer-height :initform 16
                          :type integer
                          :documentation "The height of the message buffer in pixels.")
    (minibuffer-open-height :accessor minibuffer-open-height :initform 256

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -661,7 +661,7 @@ proceeding."
     (setf (last-access buffer) (local-time:now))
     (setf (last-active-buffer *browser*) buffer)
     (set-window-title window buffer)
-    (echo-dismiss)
+    (print-status)
     (setf (active-buffer window) buffer)))
 
 (defun %get-inactive-buffer ()
@@ -748,6 +748,18 @@ Deal with URL with the following rules:
 
 (defun javascript-error-handler (condition)
   (echo-warning "JavaScript error: ~a" condition))
+
+(defun print-status ()                  ; TODO: Call when setting modes.
+  (let ((buffer (current-buffer)))
+    (ffi-print-status
+     (current-window)
+     (format nil "[~{~a~^ ~}] ~a — ~a"
+             (mapcar (lambda (m) (str:replace-all "-mode" ""
+                                                  (str:downcase
+                                                   (class-name (class-of m)))))
+                     (modes buffer))
+             (url buffer)
+             (title buffer)))))
 
 (serapeum:export-always 'current-window)
 (defun current-window (&optional no-rescan)
@@ -836,6 +848,7 @@ sometimes yields the wrong reasult."
 (define-ffi-method ffi-kill-browser ((browser browser)))
 (define-ffi-method ffi-initialize ((browser browser) urls startup-timestamp))
 (define-ffi-method ffi-inspector-show ((buffer buffer)))
+(define-ffi-method ffi-print-status ((window window) text))
 
 (define-class-type browser)
 (declaim (type (browser-type) *browser-class*))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -20,13 +20,16 @@
    (active-buffer :accessor active-buffer :initform nil)
    (active-minibuffers :accessor active-minibuffers :initform nil
                        :documentation "The stack of currently active minibuffers.")
-   (status-buffer :accessor status-buffer
+   (status-buffer :accessor status-buffer ; TODO: Delete.
                   :initform (make-minibuffer)
                   :documentation "Buffer for displaying information such as
                   current URL or event messages.")
    (status-buffer-height :accessor status-buffer-height :initform 26
                          :type integer
                          :documentation "The height of the status buffer in pixels.")
+   (message-buffer-height :accessor message-buffer-height :initform 26
+                         :type integer
+                         :documentation "The height of the message buffer in pixels.")
    (minibuffer-open-height :accessor minibuffer-open-height :initform 256
                            :type integer
                            :documentation "The height of the minibuffer when open.")
@@ -675,11 +678,10 @@ proceeding."
        (first (sort diff #'local-time:timestamp> :key #'last-access))))))
 
 (defmethod push-url-at-point ((buffer buffer) url)
-  ;; TODO: Use buffer local queue to avoid many/duplicate echo
-  (declare (ignore buffer))
-  (if (str:emptyp url)
-      (echo-dismiss)
-      (echo "→ ~a" url)))
+  (declare (ignore buffer))             ; TODO: Remove buffer argument?
+  (if (uiop:emptyp url)
+      (print-message "")
+      (print-message (str:concat "→ " url))))
 
 (defun open-urls (urls &key no-focus)
   "Create new buffers from URLs.
@@ -760,6 +762,9 @@ Deal with URL with the following rules:
                      (modes buffer))
              (url buffer)
              (title buffer)))))
+
+(defun print-message (message)
+  (ffi-print-message (current-window) message))
 
 (serapeum:export-always 'current-window)
 (defun current-window (&optional no-rescan)
@@ -849,6 +854,7 @@ sometimes yields the wrong reasult."
 (define-ffi-method ffi-initialize ((browser browser) urls startup-timestamp))
 (define-ffi-method ffi-inspector-show ((buffer buffer)))
 (define-ffi-method ffi-print-status ((window window) text))
+(define-ffi-method ffi-print-message ((window window) message))
 
 (define-class-type browser)
 (declaim (type (browser-type) *browser-class*))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -23,9 +23,16 @@
    (status-buffer-height :accessor status-buffer-height :initform 16
                          :type integer
                          :documentation "The height of the status buffer in pixels.")
+   (status-buffer-style :accessor status-buffer-style :initform
+                        (cl-css:css
+                         '((body
+                            :background "rgb(121, 121, 121)"
+                            :color "white"
+                            :padding 0
+                            :margin 0))))
    (message-buffer-height :accessor message-buffer-height :initform 16
-                         :type integer
-                         :documentation "The height of the message buffer in pixels.")
+                          :type integer
+                          :documentation "The height of the message buffer in pixels.")
    (minibuffer-open-height :accessor minibuffer-open-height :initform 256
                            :type integer
                            :documentation "The height of the minibuffer when open.")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -789,7 +789,7 @@ sometimes yields the wrong reasult."
   "Get the active buffer for the active window."
   (match (current-window)
     ((guard w w) (active-buffer w))
-    (_ (log:warn "No active window, picking last active buffer.")
+    (_ (log:debug "No active window, picking last active buffer.")
        (last-active-buffer *browser*))))
 
 (declaim (ftype (function (buffer)) set-current-buffer))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -50,7 +50,7 @@ It takes EVENT, BUFFER, WINDOW and PRINTABLE-P parameters.")
    `window-set-active-buffer' takes effect. The handlers take the
    window and the buffer as argument.")
    (status-formatter :accessor status-formatter
-                   :initform #'format-status
+                     :initform #'format-status
                      :type (function (window) string)
                      :documentation "Function of a window argument that returns
 a string to be printed in the status view.")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -26,9 +26,11 @@
    (status-buffer-style :accessor status-buffer-style :initform
                         (cl-css:css
                          '((body
-                            :background "rgb(121, 121, 121)"
-                            :color "white"
+                            :background "rgb(224, 224, 224)"
+                            :font-size "12px"
+                            :color "rgb(32, 32, 32)"
                             :padding 0
+                            :padding-left "4px"
                             :margin 0))))
    (message-buffer-height :accessor message-buffer-height :initform 16
                           :type integer

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -20,10 +20,6 @@
    (active-buffer :accessor active-buffer :initform nil)
    (active-minibuffers :accessor active-minibuffers :initform nil
                        :documentation "The stack of currently active minibuffers.")
-   (status-buffer :accessor status-buffer ; TODO: Delete.
-                  :initform (make-minibuffer)
-                  :documentation "Buffer for displaying information such as
-                  current URL or event messages.")
    (status-buffer-height :accessor status-buffer-height :initform 26
                          :type integer
                          :documentation "The height of the status buffer in pixels.")

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -753,18 +753,20 @@ Deal with URL with the following rules:
 
 (defun print-status ()                  ; TODO: Call when setting modes.
   (let ((buffer (current-buffer)))
-    (ffi-print-status
-     (current-window)
-     (format nil "[~{~a~^ ~}] ~a — ~a"
-             (mapcar (lambda (m) (str:replace-all "-mode" ""
-                                                  (str:downcase
-                                                   (class-name (class-of m)))))
-                     (modes buffer))
-             (url buffer)
-             (title buffer)))))
+    (when (and buffer (current-window))
+      (ffi-print-status
+       (current-window)
+       (format nil "[~{~a~^ ~}] ~a — ~a"
+               (mapcar (lambda (m) (str:replace-all "-mode" ""
+                                                    (str:downcase
+                                                     (class-name (class-of m)))))
+                       (modes buffer))
+               (url buffer)
+               (title buffer))))))
 
 (defun print-message (message)
-  (ffi-print-message (current-window) message))
+  (when (current-window)
+    (ffi-print-message (current-window) message)))
 
 (serapeum:export-always 'current-window)
 (defun current-window (&optional no-rescan)
@@ -777,9 +779,10 @@ Deal with URL with the following rules:
 If NO-RESCAN is non-nil, fetch the window from the `last-active-window' cache
 instead of asking the renderer for the active window.  It is faster but
 sometimes yields the wrong reasult."
-  (if (and no-rescan (slot-value *browser* 'last-active-window))
-      (slot-value *browser* 'last-active-window)
-      (ffi-window-active *browser*)))
+  (when *browser*
+    (if (and no-rescan (slot-value *browser* 'last-active-window))
+        (slot-value *browser* 'last-active-window)
+        (ffi-window-active *browser*))))
 
 (serapeum:export-always 'current-buffer)
 (defun current-buffer ()

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -35,6 +35,13 @@
    (message-buffer-height :accessor message-buffer-height :initform 16
                           :type integer
                           :documentation "The height of the message buffer in pixels.")
+   (message-buffer-style :accessor message-buffer-style :initform
+                         (cl-css:css
+                          '((body
+                             :font-size "12px"
+                             :padding 0
+                             :padding-left "4px"
+                             :margin 0))))
    (minibuffer-open-height :accessor minibuffer-open-height :initform 256
                            :type integer
                            :documentation "The height of the minibuffer when open.")

--- a/source/history.lisp
+++ b/source/history.lisp
@@ -108,7 +108,8 @@ it would not be very useful."
                         (history-data *browser*))
                        (lambda (x y)
                          (> (score-history-entry x)
-                            (score-history-entry y))))))
+                            (score-history-entry y)))))
+        (prefix-urls (delete-if #'uiop:emptyp prefix-urls)))
     (when prefix-urls
       (setf history (append prefix-urls history)))
     (lambda (input)

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -53,6 +53,7 @@ KEYCODE-LESS-DISPLAY (KEYCODE-DISPLAY)."
 (defun dispatch-input-event (event buffer window printable-p)
   "Dispatch keys in `browser's `key-stack'.
 Return nil to forward to renderer or non-nil otherwise."
+  (echo-dismiss) ; Clean up message-view on keypress.
   (with-accessors ((key-stack key-stack)) *browser*
     (labels ((keyspecs (key &optional translated-key)
                (if translated-key

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -440,15 +440,7 @@ The new webview HTML content it set as the MINIBUFFER's `content'."
         (state-changed (first (active-minibuffers (current-window))))
         (update-display (first (active-minibuffers (current-window)))))
       (progn
-        ;; TODO: We need a mode-line before we can afford to really hide the
-        ;; minibuffer.  Until then, we "blank" it.
-        (echo "")                       ; Or echo-dismiss?
-        (ffi-window-set-minibuffer-height
-         (current-window)
-         ;; TODO: Until we have a mode-line, it's best to keep the
-         ;; closed-height equal to the echo-height to avoid the stuttering,
-         ;; especially when hovering over links.
-         (status-buffer-height (current-window))))))
+        (ffi-window-set-minibuffer-height (current-window) 0))))
 
 (defun insert (characters &optional (minibuffer (current-minibuffer)))
   (setf (input-buffer minibuffer)
@@ -783,8 +775,7 @@ MESSAGE is a cl-markup list."
         (unless (active-minibuffers window)
           (erase-document status-buffer)
           (let ((style (cl-css:css
-                        `((body :border-top "4px solid dimgray"
-                                :margin "0"
+                        `((body :margin "0"
                                 :padding "0 6px")
                           (p :margin "0")))))
             (setf (content status-buffer)

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -2,9 +2,6 @@
 
 (in-package :next)
 
-;; TODO: We need to separate the minibuffer from the echo area.  The
-;; `show'/`hide' functions are not dealing well with `echo'/`echo-dismiss'.
-
 (declaim (type (list-of-characters) *word-separation-characters*))
 (defparameter *word-separation-characters* '(#\: #\/ #\- #\. #\Space #\ )
   "Characters delimiting words (space, colon, slash, dot, etc).")
@@ -62,8 +59,7 @@
        "M-u" #'minibuffer-unmark-all))
     ;; TODO: We could have VI bindings for the minibuffer too.
     ;; But we need to make sure it's optional + to have an indicator
-    ;; for the mode.  This requires either a change of cursor or a
-    ;; echo area separate from the minibuffer.
+    ;; for the mode.
     )))
 
 (defclass-export minibuffer (buffer)
@@ -202,7 +198,7 @@ This should not rely on the minibuffer's content.")
                           (input-prompt nil explicit-input-prompt)
                           (input-buffer nil explicit-input-buffer)
                           (invisible-input-p nil explicit-invisible-input-p)
-                          (show-completion-count t explicit-show-completion-count)
+                          (show-completion-count t explicit-show-completion-count) ; TODO: Rename to hide-completion-count and reverse default value.
                           (history nil explicit-history)
                           (multi-selection-p nil explicit-multi-selection-p))
   "See the `minibuffer' class for the argument documentation."
@@ -785,11 +781,12 @@ Untrusted content should be given as argument with a format string."
         (unless (str:emptyp text)
           (log:info "~s" text)))
     (error ()
-      (log:warn "Failed to echo these args: ~s~&Possible improvements:
-- pass multiple arguments and use format strings for untrusted content. Don't pre-construct a single string that could contain tildes.
-  example: do (echo \"directory is\ ~~a \"~~/Downloads/\")
+      (log:warn "Failed to echo these args: ~s
+Possible improvements:
+- Pass multiple arguments and use format strings for untrusted content. Don't pre-construct a single string that could contain tildes.
+  Example: do (echo \"directory is\ ~~a \"~~/Downloads/\")
            instead of (echo \"directory is ~~/Downloads/\")
-- use echo-safe or use the ~~s directive directly." args))))
+- Use `echo-safe' or use the ~~s directive directly." args))))
 
 (serapeum:export-always 'echo-safe)
 (defun echo-safe (&rest args)

--- a/source/minibuffer.lisp
+++ b/source/minibuffer.lisp
@@ -835,21 +835,8 @@ Untrusted content should be given as argument with a format string."
 
 (serapeum:export-always 'echo-dismiss)
 (defmethod echo-dismiss ()
-  ;; TODO: If we erase the document here, it will show a blank widget instead
-  ;; of the minibuffer when we don't fully hide it.  We can only erase the
-  ;; document when we have a mode-line we can fully hide the minibuffer.
-  ;; (erase-document minibuffer)
-  ;; TODO: We should only display this default text until we have a mode-line.
-  (let ((buffer (current-buffer)))
-    (%echo-status (format nil "[~{~a~^ ~}] ~a — ~a"
-                          (mapcar (lambda (m) (str:replace-all "-mode" ""
-                                                               (str:downcase
-                                                                (class-name (class-of m)))))
-                                  (modes buffer))
-                          (url buffer)
-                          (title buffer))
-                  ;; Don't add to the *Messages* buffer:
-                  :message nil)))
+  ;; Don't add to the *Messages* buffer:
+  (%echo-status "" :message nil))
 
 (declaim (ftype (function (ring:ring) string) ring-insert-clipboard))
 (serapeum:export-always 'ring-insert-clipboard)

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -68,6 +68,7 @@ The buffer is returned so that mode activation can be chained."
                          (funcall (constructor new-mode) new-mode))
                        (push new-mode (modes buffer))
                        (hooks:run-hook (enable-hook new-mode) new-mode))
+                     (print-status)
                      (log:debug "~a enabled." ',name))
                    (when existing-instance
                      (hooks:run-hook (disable-hook existing-instance) existing-instance)
@@ -75,6 +76,7 @@ The buffer is returned so that mode activation can be chained."
                        (funcall (destructor existing-instance) existing-instance))
                      (setf (modes buffer) (delete existing-instance
                                                   (modes buffer)))
+                     (print-status)
                      (log:debug "~a disabled." ',name))))
              buffer)))))
 

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -594,11 +594,14 @@ Warning: This behaviour may change in the future."
                     (ps:lisp text)))))))
 
 (defmethod ffi-print-message ((window gtk-window) text)
-  (with-slots (message-view) window
-    (webkit2:webkit-web-view-evaluate-javascript
-     (message-view window)
-     (ps:ps (setf (ps:@ document Body |innerHTML|)
-                  (ps:lisp text))))))
+  (let ((text (markup:markup
+               (:head (:style (message-buffer-style window)))
+               (:body text))))
+    (with-slots (message-view) window
+      (webkit2:webkit-web-view-evaluate-javascript
+       (message-view window)
+       (ps:ps (setf (ps:@ document Body |innerHTML|)
+                    (ps:lisp text)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; See https://github.com/Ferada/cl-cffi-gtk/issues/37.

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -584,11 +584,14 @@ Warning: This behaviour may change in the future."
    (webkit:webkit-web-view-get-inspector (gtk-object buffer))))
 
 (defmethod ffi-print-status ((window gtk-window) text)
-  (with-slots (status-view) window
-    (webkit2:webkit-web-view-evaluate-javascript
-     (status-view window)
-     (ps:ps (setf (ps:@ document Body |innerHTML|) ; TODO: Rename all "Body" to "body".
-                  (ps:lisp text))))))
+  (let ((text (markup:markup
+               (:head (:style (status-buffer-style window)))
+               (:body text))))
+    (with-slots (status-view) window
+      (webkit2:webkit-web-view-evaluate-javascript
+       (status-view window)
+       (ps:ps (setf (ps:@ document Body |innerHTML|) ; TODO: Rename all "Body" to "body".
+                    (ps:lisp text)))))))
 
 (defmethod ffi-print-message ((window gtk-window) text)
   (with-slots (message-view) window

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -90,7 +90,7 @@ want to change the behaviour of modifiers, for instance swap 'control' and
                                     :default-height 768))
     (setf box-layout (make-instance 'gtk:gtk-box
                                     :orientation :vertical
-                                    :spacing 4))
+                                    :spacing 0))
     (setf minibuffer-container (make-instance 'gtk:gtk-box
                                               :orientation :vertical
                                               :spacing 0))

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -52,6 +52,8 @@ want to change the behaviour of modifiers, for instance swap 'control' and
    (minibuffer-view :accessor minibuffer-view)
    (status-container :accessor status-container)
    (status-view :accessor status-view)
+   (message-container :accessor message-container)
+   (message-view :accessor message-view)
    (key-string-buffer :accessor key-string-buffer)))
 
 (define-class-type window)
@@ -79,6 +81,7 @@ want to change the behaviour of modifiers, for instance swap 'control' and
   (with-slots (gtk-object box-layout active-buffer
                minibuffer-container minibuffer-view
                status-container status-view
+               message-container message-view
                id key-string-buffer) window
     (setf id (get-unique-window-identifier *browser*))
     (setf gtk-object (make-instance 'gtk:gtk-window
@@ -91,6 +94,9 @@ want to change the behaviour of modifiers, for instance swap 'control' and
     (setf minibuffer-container (make-instance 'gtk:gtk-box
                                               :orientation :vertical
                                               :spacing 0))
+    (setf message-container (make-instance 'gtk:gtk-box
+                                           :orientation :vertical
+                                           :spacing 0))
     (setf status-container (make-instance 'gtk:gtk-box
                                           :orientation :vertical
                                           :spacing 0))
@@ -105,6 +111,12 @@ want to change the behaviour of modifiers, for instance swap 'control' and
     (gtk:gtk-box-pack-start status-container status-view :expand t)
     (setf (gtk:gtk-widget-size-request status-container)
           (list -1 (status-buffer-height window)))
+
+    (setf message-view (make-instance 'webkit:webkit-web-view))
+    (gtk:gtk-box-pack-end box-layout message-container :expand nil)
+    (gtk:gtk-box-pack-start message-container message-view :expand t)
+    (setf (gtk:gtk-widget-size-request message-container)
+          (list -1 (message-buffer-height window)))
 
     (setf minibuffer-view (make-instance 'webkit:webkit-web-view))
     (gtk:gtk-box-pack-end box-layout minibuffer-container :expand nil)
@@ -454,7 +466,9 @@ Warning: This behaviour may change in the future."
         ((webkit:webkit-hit-test-result-image-uri hit-test-result)
          (push-url-at-point buffer (webkit:webkit-hit-test-result-image-uri hit-test-result)))
         ((webkit:webkit-hit-test-result-media-uri hit-test-result)
-         (push-url-at-point buffer (webkit:webkit-hit-test-result-media-uri hit-test-result)))))
+         (push-url-at-point buffer (webkit:webkit-hit-test-result-media-uri hit-test-result)))
+        (t
+         (push-url-at-point buffer ""))))
 
 (defmethod ffi-window-make ((browser gtk-browser))
   "Make a window."
@@ -574,6 +588,13 @@ Warning: This behaviour may change in the future."
     (webkit2:webkit-web-view-evaluate-javascript
      (status-view window)
      (ps:ps (setf (ps:@ document Body |innerHTML|) ; TODO: Rename all "Body" to "body".
+                  (ps:lisp text))))))
+
+(defmethod ffi-print-message ((window gtk-window) text)
+  (with-slots (message-view) window
+    (webkit2:webkit-web-view-evaluate-javascript
+     (message-view window)
+     (ps:ps (setf (ps:@ document Body |innerHTML|)
                   (ps:lisp text))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -90,7 +90,7 @@ want to change the behaviour of modifiers, for instance swap 'control' and
                                     :default-height 768))
     (setf box-layout (make-instance 'gtk:gtk-box
                                     :orientation :vertical
-                                    :spacing 0))
+                                    :spacing 4))
     (setf minibuffer-container (make-instance 'gtk:gtk-box
                                               :orientation :vertical
                                               :spacing 0))
@@ -122,7 +122,7 @@ want to change the behaviour of modifiers, for instance swap 'control' and
     (gtk:gtk-box-pack-end box-layout minibuffer-container :expand nil)
     (gtk:gtk-box-pack-start minibuffer-container minibuffer-view :expand t)
     (setf (gtk:gtk-widget-size-request minibuffer-container)
-          (list -1 (status-buffer-height window)))
+          (list -1 0))
 
     (gtk:gtk-container-add gtk-object box-layout)
     (setf (slot-value *browser* 'last-active-window) window)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -106,17 +106,17 @@ want to change the behaviour of modifiers, for instance swap 'control' and
     ;; Add the views to the box layout and to the window
     (gtk:gtk-box-pack-start box-layout (gtk-object active-buffer))
 
-    (setf status-view (make-instance 'webkit:webkit-web-view))
-    (gtk:gtk-box-pack-end box-layout status-container :expand nil)
-    (gtk:gtk-box-pack-start status-container status-view :expand t)
-    (setf (gtk:gtk-widget-size-request status-container)
-          (list -1 (status-buffer-height window)))
-
     (setf message-view (make-instance 'webkit:webkit-web-view))
     (gtk:gtk-box-pack-end box-layout message-container :expand nil)
     (gtk:gtk-box-pack-start message-container message-view :expand t)
     (setf (gtk:gtk-widget-size-request message-container)
           (list -1 (message-buffer-height window)))
+
+    (setf status-view (make-instance 'webkit:webkit-web-view))
+    (gtk:gtk-box-pack-end box-layout status-container :expand nil)
+    (gtk:gtk-box-pack-start status-container status-view :expand t)
+    (setf (gtk:gtk-widget-size-request status-container)
+          (list -1 (status-buffer-height window)))
 
     (setf minibuffer-view (make-instance 'webkit:webkit-web-view))
     (gtk:gtk-box-pack-end box-layout minibuffer-container :expand nil)

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -401,6 +401,7 @@ Otherwise go forward to the only child."
     ;; e.g. webkit_web_view_set_zoom_level.
     (unzoom-page :buffer buffer)
     (set-window-title (current-window) buffer)
+    (print-status)
     (htree:add-child (make-instance 'buffer-description
                                     :url url
                                     :title (title buffer))

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -412,8 +412,9 @@ Otherwise go forward to the only child."
     (match (session-store-function *browser*)
       ((guard f f) (funcall f))))
   (echo "Finished loading: ~a." url)
-  ;; TODO: Wait some time before dismissing the minibuffer.
-  (echo-dismiss))
+  ;; TODO: Wait some time before dismissing the echo?
+  ;; (echo-dismiss)
+  )
 
 (defmethod object-string ((node htree:node))
   (object-string (when node (htree:data node))))


### PR DESCRIPTION
This adds 2 components to the UI:
- A status view.
- A message view.

It's a fantastic improvement in my opinion.  No more screenspace contentions, no more race conditions!
`M-x next-version` and `M-x next-init-time` work again!

Aestetically there is more work to be done.  The dimensions are not ideal, the borders are not well set, etc.

We could add a command to toggle the status view and message view.
Shall we make it a mode?

I figured that "message" was more familiar than "echo" (which is more of an Emacs term).
Shall we rename all `echo*` commands to `message*`?

In my opinion this is ready to be merged.  Next I'll clean up minibuffer.lisp a little.