### PR TITLE
Contextual keys

### DIFF
--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -565,7 +565,11 @@ Warning: This behaviour may change in the future."
 (defmethod ffi-generate-input-event ((window gtk-window) event)
   ;; The "send_event" field is used to mark the event as an "unconsumed"
   ;; keypress.  The distinction allows us to avoid looping indefinitely.
-  (setf (gdk:gdk-event-button-send-event event) t)
+  (etypecase event
+    (gdk:gdk-event-button
+     (setf (gdk:gdk-event-button-send-event event) t))
+    (gdk:gdk-event-key
+     (setf (gdk:gdk-event-key-send-event event) t)))
   (gtk:gtk-main-do-event event))
 
 (defmethod ffi-generated-input-event-p ((window gtk-window) event)

--- a/source/utility.lisp
+++ b/source/utility.lisp
@@ -68,6 +68,7 @@ before running this command."
          (open (error-output-path browser) :direction :output :if-does-not-exist :create
                                              :if-exists :append))))
 
+(export-always 'funcall-safely)
 (defun funcall-safely (f &rest args)
   "Like `funcall' except that if `*keep-alive*' is nil (e.g. the program is run
 from a binary) then any condition is logged instead of triggering the debugger."

--- a/source/vi-mode.lisp
+++ b/source/vi-mode.lisp
@@ -66,7 +66,7 @@ vi-normal-mode.")
        ;; TODO: Forwarding C-v / button2 crashes cl-webkit.  See
        ;; https://github.com/atlas-engineer/next/issues/593#issuecomment-599051350
        "C-v" #'next/web-mode:paste
-       "button2" #'next/web-mode:paste
+       "button2" #'next/web-mode:maybe-paste
        "escape" #'vi-normal-mode
        "button1" #'vi-button1)))
    (destructor
@@ -86,14 +86,6 @@ vi-normal-mode.")
         (vi-normal-mode :activate nil :buffer buffer)
         (setf (keymap-scheme-name buffer) scheme:vi-insert))))))
 
-(define-parenscript %clicked-in-input? ()
-  (ps:chain document active-element tag-name))
-
-(declaim (ftype (function ((or string null)) boolean) input-tag-p))
-(defun input-tag-p (tag)
-  (or (string= tag "INPUT")
-      (string= tag "TEXTAREA")))
-
 (define-command vi-button1 (&optional (buffer (current-buffer)))
   "Enable VI insert mode when focus is on an input element on the web page."
   (let ((root-mode (find-mode buffer 'root-mode)))
@@ -102,13 +94,13 @@ vi-normal-mode.")
     (ffi-generate-input-event
      (current-window)
      (last-event (buffer root-mode)))
-    (%clicked-in-input?
+    (next/web-mode:%clicked-in-input?
      :callback (lambda (response)
                  (cond
-                   ((and (input-tag-p response)
+                   ((and (next/web-mode:input-tag-p response)
                          (find-submode (buffer root-mode) 'vi-normal-mode))
                     (vi-insert-mode))
-                   ((and (not (input-tag-p response))
+                   ((and (not (next/web-mode:input-tag-p response))
                          (find-submode (buffer root-mode) 'vi-insert-mode))
                     (vi-normal-mode)))))))
 

--- a/source/web-mode.lisp
+++ b/source/web-mode.lisp
@@ -3,8 +3,9 @@
   (:import-from #:keymap #:define-key #:define-scheme)
   (:documentation "Mode for web pages"))
 (in-package :next/web-mode)
-
-(trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (trivial-package-local-nicknames:add-package-local-nickname :alex :alexandria)
+  (trivial-package-local-nicknames:add-package-local-nickname :sera :serapeum))
 
 ;; TODO: Remove web-mode from special buffers (e.g. help).
 ;; This is required because special buffers cannot be part of a history (and it breaks it).
@@ -34,7 +35,7 @@
        "C-u M-g" #'follow-hint-new-buffer
        "C-x C-w" #'copy-hint-url
        "C-v" #'paste
-       "button2" #'paste
+       "button2" #'maybe-paste
        "C-c" #'copy
        "button9" #'history-forwards
        "button8" #'history-backwards
@@ -53,8 +54,8 @@
        "C-f" #'search-buffer
        "M-f" #'remove-search-hints
        "C-." #'jump-to-heading
-       "end" #'scroll-to-bottom
-       "home" #'scroll-to-top
+       "end" #'maybe-scroll-to-bottom
+       "home" #'maybe-scroll-to-top
        "C-down" #'scroll-to-bottom
        "C-up" #'scroll-to-top
        "M-v" #'scroll-page-up
@@ -206,6 +207,52 @@
   ;; (set-url (default-new-buffer-url (buffer %mode))
   ;;                 (buffer %mode))
   )
+
+(sera:export-always '%clicked-in-input?)
+(define-parenscript %clicked-in-input? ()
+  (ps:chain document active-element tag-name))
+
+(sera:export-always 'input-tag-p)
+(declaim (ftype (function ((or string null)) boolean) input-tag-p))
+(defun input-tag-p (tag)
+  (or (string= tag "INPUT")
+      (string= tag "TEXTAREA")))
+
+(defun call-input-command-or-forward (command &key (buffer (current-buffer))
+                                          (window (current-window)))
+  (%clicked-in-input?
+   :callback (lambda (response)
+               (if (input-tag-p response)
+                   (funcall-safely command)
+                   (ffi-generate-input-event
+                    window
+                    (last-event buffer))))))
+
+(defun call-non-input-command-or-forward (command &key (buffer (current-buffer))
+                                          (window (current-window)))
+  (%clicked-in-input?
+   :callback (lambda (response)
+               (if (input-tag-p response)
+                   (ffi-generate-input-event
+                    window
+                    (last-event buffer))
+                   (funcall-safely command)))))
+
+(define-command maybe-paste (&optional (buffer (current-buffer)))
+  "Paste text if active element is an input tag, forward event otherwise."
+  ;; TODO: This does not work properly.
+  ;; If an input element is active and we press button2, it pastes instead of
+  ;; opening the link in a new tab.
+  ;; We should check if the mouse cursor is over a link.
+  (call-input-command-or-forward #'paste :buffer buffer))
+
+(define-command maybe-scroll-to-bottom (&optional (buffer (current-buffer)))
+  "Scroll to bottom if no input element is active, forward event otherwise."
+  (call-non-input-command-or-forward #'scroll-to-bottom :buffer buffer))
+
+(define-command maybe-scroll-to-top (&optional (buffer (current-buffer)))
+  "Scroll to top if no input element is active, forward event otherwise."
+  (call-non-input-command-or-forward #'scroll-to-top :buffer buffer))
 
 (declaim (ftype (function (htree:node &optional buffer)) set-url-from-history))
 (defun set-url-from-history (history-node &optional (buffer (current-buffer)))


### PR DESCRIPTION
@hsanjuan Can you confirm this works for you?

I haven't fixed SPACE for now.
There is also an issue with button2 that this pull request fails to fix properly.
button2 (the mouse wheel button) is supposed to open a link in a new buffer.
But if an input element is active, it will paste instead.

Is there a way to detect the HTML element under the mouse cursor?