### PR TITLE
History uri fixes

### DIFF
--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -309,11 +309,18 @@ defined in any package and is unique."
               ((guard c c) (funcall (sym c) :buffer buffer :activate t))
               (_ (log:warn "Mode command ~a not found." mode-class))))))))
 
+(defmethod on-signal-notify-uri ((buffer buffer) no-uri)
+  "Set BUFFER's `url' slot, then dispatch `on-signal-notify-uri' over the
+BUFFER's modes."
+  (declare (ignore no-uri))
+  (setf (url buffer) (ffi-buffer-uri buffer))
+  (dolist (mode (modes buffer))
+    (on-signal-notify-uri mode (url buffer))))
+
 (defmethod on-signal-load-committed ((buffer buffer) url)
   nil)
 
 (defmethod on-signal-load-finished ((buffer buffer) url)
-  (setf (url buffer) url)
   (with-result (title (%%buffer-get-title :buffer buffer))
     (setf (title buffer) title)
     ;; Warning: We can only dispatch `on-signal-load-finished' after the title has
@@ -881,6 +888,7 @@ sometimes yields the wrong reasult."
 (define-ffi-method ffi-window-delete ((window window)))
 (define-ffi-method ffi-window-fullscreen ((window window)))
 (define-ffi-method ffi-window-unfullscreen ((window window)))
+(define-ffi-method ffi-buffer-uri ((buffer buffer)))
 (define-ffi-method ffi-window-make ((browser browser)))
 (define-ffi-method ffi-window-to-foreground ((window window)))
 (define-ffi-method ffi-window-set-title ((window window) title))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -316,7 +316,7 @@ defined in any package and is unique."
   (setf (url buffer) url)
   (with-result (title (%%buffer-get-title :buffer buffer))
     (setf (title buffer) title)
-    ;; Warning: We can only dispatch on-signal-load-committed after the title has
+    ;; Warning: We can only dispatch `on-signal-load-finished' after the title has
     ;; been set, lest we get a race condition with the title being set too late.
     (dolist (mode (modes buffer))
       (on-signal-load-finished mode url))))

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -167,10 +167,7 @@ URL is first transformed by `parse-url', then by BUFFER's `set-url-hook'."
             (setf url new-url)))
       (error (c)
         (log:error "In `set-url-hook': ~a" c)))
-    (ffi-buffer-load buffer url)
-    ;; Set buffer's URL after the FFI call so that the call has access to the
-    ;; old buffer URL.
-    (setf (url buffer) url)))
+    (ffi-buffer-load buffer url)))
 
 (define-command insert-candidate-or-search-engine (&optional (minibuffer (current-minibuffer)))
   "Paste clipboard text or to input.

--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -167,8 +167,10 @@ URL is first transformed by `parse-url', then by BUFFER's `set-url-hook'."
             (setf url new-url)))
       (error (c)
         (log:error "In `set-url-hook': ~a" c)))
-    (setf (url buffer) url)
-    (ffi-buffer-load buffer url)))
+    (ffi-buffer-load buffer url)
+    ;; Set buffer's URL after the FFI call so that the call has access to the
+    ;; old buffer URL.
+    (setf (url buffer) url)))
 
 (define-command insert-candidate-or-search-engine (&optional (minibuffer (current-minibuffer)))
   "Paste clipboard text or to input.

--- a/source/mode.lisp
+++ b/source/mode.lisp
@@ -261,10 +261,20 @@ If there is no corresponding keymap, return nil."
   (keymap:get-keymap (keymap-scheme-name (buffer mode))
                      (keymap-scheme mode)))
 
+(defmethod on-signal-notify-uri ((mode root-mode) url)
+  (set-window-title (current-window) (buffer mode))
+  (print-status)
+  url)
+
 (defmethod on-signal-load-committed ((mode root-mode) url)
   url)
 
 (defmethod on-signal-load-finished ((mode root-mode) url)
+  ;; TODO: Setting the default zoom level works with pure Javascript, but it
+  ;; can only be done after the URL has been loaded which is a bit of a
+  ;; kludge.  Instead we could add an FFI endpoint,
+  ;; e.g. webkit_web_view_set_zoom_level.
+  (unzoom-page :buffer (buffer mode))
   url)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -455,7 +455,7 @@ Warning: This behaviour may change in the future."
            (print-status (format nil "Loading: ~a" (url buffer))
                          (get-containing-window-for-buffer buffer *browser*)))
           ((eq load-event :webkit-load-redirected) nil)
-          ;; TODO: load-committed is deprecated.  Only use load-status and load-finished.
+          ;; WARNING: load-committed may be deprecated (reference?).  Prefer load-status and load-finished.
           ((eq load-event :webkit-load-committed)
            (on-signal-load-committed buffer url))
           ((eq load-event :webkit-load-finished)

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -380,9 +380,17 @@ Warning: This behaviour may change in the future."
      (declare (ignore web-view errors))
      ;; TODO: Add hint on how to accept certificate to the HTML content.
      (on-signal-load-failed-with-tls-errors buffer certificate failing-uri)))
+  (gobject:g-signal-connect
+   (gtk-object buffer) "notify::uri"
+   (lambda (web-view param-spec)
+     (declare (ignore web-view param-spec))
+     (on-signal-notify-uri buffer nil)))
   ;; Modes might require that buffer exists, so we need to initialize them
   ;; after the view has been created.
   (initialize-modes buffer))
+
+(defmethod ffi-buffer-uri ((buffer gtk-buffer))
+  (webkit:webkit-web-view-uri (gtk-object buffer)))
 
 (defmethod on-signal-load-failed-with-tls-errors ((buffer gtk-buffer) certificate url)
   "Return nil to propagate further (i.e. raise load-failed signal), T otherwise."
@@ -459,6 +467,7 @@ Warning: This behaviour may change in the future."
           ((eq load-event :webkit-load-committed)
            (on-signal-load-committed buffer url))
           ((eq load-event :webkit-load-finished)
+           (echo "Finished loading: ~a." (url buffer))
            (on-signal-load-finished buffer url)))))
 
 (defmethod on-signal-mouse-target-changed ((buffer gtk-buffer) hit-test-result modifiers)


### PR DESCRIPTION
I wanted to fix all history-related issues together because I wanted to make sure that the variouas fixes would be consistent.

1. DuckDuckGo /l spurious history entry.  See #211.  I've inspected WebKitGTK's history and noticed that the spurious entry gets added there too, but as soon as the page is done loading it gets replace by the final URL.  I don't know how they do that.  In the mean time, I've implemented a stupid URL-blacklist workaround.  Should be good enough for 2.0 at least.

2. WebKitGTK history cache is now used!  Try going back and forth, it should now be lightning fast!  (If you have a fast connection, enable Tor to notice the difference.)  This is one of my favourite updates in weeks (with the status bar)!  Fixes #613 .

3. Update URL when browsing GitHub files and clicking on anchors.  See #668 .
This problem was re-introduced with the FFI bindings.  @jmercouris: To set the URL in WebKitGTK we can't rely on the URL passed during the :load-changed signals because Javascript URL changes or TOC clicks won't be registered.  Instead we must use the notify:uri signal.  We had the same problem some versions ago with the platform ports ;)