### PR TITLE
Composed request resource

### DIFF
--- a/libraries/hooks/hooks.lisp
+++ b/libraries/hooks/hooks.lisp
@@ -228,6 +228,7 @@ This is an acceptable `combination' for `hook'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun add-hook-internal (hook handler &key append)
   "Add HANDLER to HOOK if not already in it.
+Return HOOK.
 HANDLER is also not added if in the `disabled-handlers'.
 If APPEND is non-nil, HANDLER is added at the end."
   (serapeum:synchronized (hook)
@@ -235,7 +236,8 @@ If APPEND is non-nil, HANDLER is added at the end."
                 (member handler (disabled-handlers hook) :test #'equals))
       (if append
           (alexandria:appendf (symbol-value hook) (list handler))
-          (pushnew handler (handlers hook) :test #'equals)))))
+          (pushnew handler (handlers hook) :test #'equals)))
+    hook))
 
 (declaim (ftype (function ((or handler symbol) list) (or handler boolean)) find-handler))
 (defun find-handler (handler-or-name handlers)
@@ -394,7 +396,7 @@ will be automatically encapsulated with make-handler-NAME."
        (defclass ,hook-class-name (hook)
          ((handler-class :initform ',handler-class-name)))
        (defmethod add-hook ((hook ,hook-class-name) (handler ,handler-class-name) &key append)
-         ,(format nil "Add HANDLER to HOOK.
+         ,(format nil "Add HANDLER to HOOK.  Return HOOK.
 HOOK must be of type ~a
 HANDLER must be of type ~a."
                   hook-class-name

--- a/libraries/hooks/package.lisp
+++ b/libraries/hooks/package.lisp
@@ -24,6 +24,7 @@
    ;; Handler class:
    #:handler
    #:name
+   #:fn
    #:description
    #:handler-type
    #:place

--- a/source/blocker-mode.lisp
+++ b/source/blocker-mode.lisp
@@ -134,8 +134,12 @@ Example:
      (constructor
       :initform
       (lambda (mode)
-        (hooks:add-hook (request-resource-hook (buffer mode))
-                        (next:make-handler-resource #'request-resource-block))))))
+        (if (request-resource-hook (buffer mode))
+            (hooks:add-hook (request-resource-hook (buffer mode))
+                            (make-handler-resource #'request-resource-block))
+            (make-hook-resource
+             :combination #'combine-composed-hook-until-non-nil-second-value
+             :handlers (list (make-handler-resource #'request-resource-block))))))))
 
 (defmethod blacklisted-host-p ((mode blocker-mode) host)
   "Return non-nil of HOST if found in the hostlists of MODE.

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -208,7 +208,15 @@ second value.
 Newest hook is run first.
 If :FORWARD is returned, the resource loading of the returned `request-data' is
 deferred to the renderer.
-If :STOP is returned, stop the the hook.")
+If :STOP is returned, stop the the hook.
+
+Example:
+
+\(define-configuration buffer
+  ((request-resource-hook
+    (reduce #'hooks:add-hook
+            (mapcar #'make-handler-resource (list #'old-reddit-handler #'auto-proxy-handler))
+            :initial-value %slot-default))))")
    (default-new-buffer-url :accessor default-new-buffer-url :initform "https://next.atlas.engineer/start"
                            :documentation "The URL set to a new blank buffer opened by Next.")
    (scroll-distance :accessor scroll-distance :initform 50 :type number

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -16,7 +16,7 @@
                                            (values request-data
                                                    &optional (or (eql :stop)
                                                                  (eql :forward)))))
-(export-always 'make-handler-resource)
+(export-always '(make-hook-resource make-handler-resource))
 
 (defclass-export window ()
   ((id :accessor id :initarg :id)
@@ -116,6 +116,7 @@ This can apply to specific buffer."))
 (export-always '*proxy-class*)
 (defparameter *proxy-class* 'proxy)
 
+(export-always 'combine-composed-hook-until-non-nil-second-value)
 (defmethod combine-composed-hook-until-non-nil-second-value ((hook hooks:hook) &rest args)
   "Return the result of the composition of the HOOK handlers on ARGS, from
 oldest to youngest.  Stop processsing when a handler returns a non-nil second value.

--- a/source/renderer-gtk.lisp
+++ b/source/renderer-gtk.lisp
@@ -441,20 +441,31 @@ Warning: This behaviour may change in the future."
       (setf modifiers (funcall (modifier-translator *browser*)
                                (webkit:webkit-navigation-action-get-modifiers navigation-action))))
     (setf url (webkit:webkit-uri-request-uri request))
-    (if (or (null (hooks:handlers (request-resource-hook buffer)))
-            (eq :forward (hooks:run-hook (request-resource-hook buffer)
-                                         buffer
-                                         :url url
-                                         :keys (unless (uiop:emptyp mouse-button)
-                                                 (list (keymap:make-key
-                                                        :value mouse-button
-                                                        :modifiers modifiers)))
-                                         :event-type event-type
-                                         :is-new-window is-new-window
-                                         :is-known-type is-known-type)))
-        ;; nil means "forward to renderer".
-        nil
-        t)))
+    (if (null (hooks:handlers (request-resource-hook buffer)))
+        nil ; Forward to renderer.
+        (multiple-value-bind (request-data status)
+            (hooks:run-hook (request-resource-hook buffer)
+                            (make-instance 'request-data
+                                           :buffer buffer
+                                           :url url
+                                           :keys (unless (uiop:emptyp mouse-button)
+                                                   (list (keymap:make-key
+                                                          :value mouse-button
+                                                          :modifiers modifiers)))
+                                           :event-type event-type
+                                           :new-window-p is-new-window
+                                           :known-type-p is-known-type))
+          (match status
+            ((or :forward nil)
+             (if (or (null request-data) (string= url (url request-data)))
+                 nil ; Forward to renderer.
+                 (progn
+                   (setf (webkit:webkit-uri-request-uri request) (url request-data))
+                   (webkit:webkit-web-view-load-request (gtk-object buffer) request)
+                   ;; Don't forward to renderer:
+                   t)))
+            ;; Don't forward to renderer.
+            (_ t))))))
 
 (defmethod on-signal-load-changed ((buffer gtk-buffer) load-event)
   (let ((url (webkit:webkit-web-view-uri (gtk-object buffer))))

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -2,16 +2,6 @@
 
 (in-package :next)
 
-(export-always 'resource-handler-return-type)
-(deftype resource-handler-return-type ()
-  `(or (eql :forward)
-       (eql :stop)
-       boolean))
-
-(export-always 'resource-handler-type)
-(deftype resource-handler-type ()
-  `(function (buffer &key &allow-other-keys) resource-handler-return-type))
-
 ;; trivial-types:proper-list doesn't check its element type.
 
 (defun list-of-type-p (list typep)


### PR DESCRIPTION
See the commit messages.

After this gets merged:

- Shall we rename the lengthy `request-resource-hook` to `request-hook`?
- `set-url-hook` seems to be completely superseded by `request-hook`.  I suggest removing it for now because it's not very useful and might confuse users as in #517.  Or at least unexport it for now and if it ever gets requested by some users we can reenable it later.  It's easier in this direction because we can't remove / unexport after 2.0 (it would be API-breaking).