### PR TITLE
Wip application mode

### DIFF
--- a/source/application-mode.lisp
+++ b/source/application-mode.lisp
@@ -1,11 +1,31 @@
-;;; application-mode.lisp --- major mode for "web applications"
-;;; has no history or bindings to avoid interference with "web applications"'
+(uiop:define-package :next/application-mode
+    (:use :common-lisp :trivia :next)
+  (:documentation "Forward all keybindings to the web view except those in the `override-map'."))
+(in-package :next/application-mode)
 
-(in-package :next)
-
-;; TODO: Finish it!  We can move the active modes to a list of backed up modes,
-;; and have one "escape key" bound to a function that would restore the backup modes.
+;; Moving modes out of the `modes' slot is a bad idea: too many parts rely on
+;; the presence of the `modes' slot.
 
 (define-mode application-mode ()
-    "Mode that forwards all keys to the renderer."
-  ())
+  "Mode that forwards all keys to the renderer."
+  ((destructor
+    :initform
+    (lambda (mode)
+      (hooks:remove-hook (current-keymaps-hook (buffer mode))
+                         'keep-override-map)))
+   (constructor
+    :initform
+    (lambda (mode)
+      (if (current-keymaps-hook (buffer mode))
+          (hooks:add-hook (current-keymaps-hook (buffer mode))
+                          (make-handler-keymaps-buffer #'keep-override-map))
+          (make-hook-keymaps-buffer
+             :combination #'hooks:combine-composed-hook
+             :handlers (list #'keep-override-map)))))))
+
+(declaim (ftype (function (list-of-keymaps buffer) (values list-of-keymaps buffer))
+                keep-override-map))
+(defun keep-override-map (keymaps buffer)
+  (if (active-minibuffers (current-window))
+      (values keymaps buffer)
+      (values (list (override-map buffer)) buffer)))

--- a/source/browser.lisp
+++ b/source/browser.lisp
@@ -12,6 +12,10 @@
 (hooks:define-hook-type minibuffer (function (minibuffer)))
 (hooks:define-hook-type download (function (download-manager:download)))
 (hooks:define-hook-type window-buffer (function (window buffer)))
+
+(hooks:define-hook-type keymaps-buffer (function (list-of-keymaps buffer)
+                                                 (values &optional list-of-keymaps buffer)))
+(export-always '(make-hook-keymaps-buffer make-handler-keymaps-buffer))
 (hooks:define-hook-type resource (function (request-data)
                                            (values request-data
                                                    &optional (or (eql :stop)
@@ -189,6 +193,13 @@ Dead buffers (i.e. those not associated with a web view) have an empty ID.")
     :initarg :keymap-scheme-name
     :initform scheme:cua
     :type keymap:scheme-name
+    :documentation "The keymap scheme that will be used for all modes in the current buffer.")
+   (current-keymaps-hook
+    :accessor current-keymaps-hook
+    :initarg :current-keymaps-hook
+    :type hook-keymaps-buffer
+    :initform (make-hook-keymaps-buffer
+               :combination #'hooks:combine-composed-hook)
     :documentation "The keymap scheme that will be used for all modes in the current buffer.")
    (override-map :accessor override-map
                  :initarg :override-map

--- a/source/input.lisp
+++ b/source/input.lisp
@@ -21,12 +21,16 @@ Example:
 (export-always 'current-keymaps)
 (defun current-keymaps (&optional (window (current-window))) ; TODO: Take buffer/minibuffer as argument instead?
   "Return the list of `keymap' for the current buffer, ordered by priority."
-  (let ((buffer (active-buffer window)))
-    (when buffer
-      (cons (override-map buffer)
-            (delete nil (mapcar #'keymap (modes (if (active-minibuffers window)
-                                                    (current-minibuffer)
-                                                    buffer))))))))
+  (let* ((buffer (active-buffer window))
+         (keymaps
+           (when buffer
+             (cons (override-map buffer)
+                   (delete nil (mapcar #'keymap (modes (if (active-minibuffers window)
+                                                           (current-minibuffer)
+                                                           buffer))))))))
+    (if (current-keymaps-hook buffer)
+        (hooks:run-hook (current-keymaps-hook buffer) keymaps buffer)
+        keymaps)))
 
 (defun all-keymaps (&optional (window (current-window)))
   "Return all keymaps for WINDOW, including the buffer keymaps and the

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -28,6 +28,8 @@ Example:
 (define-list-type 'character)
 (export-always 'list-of-strings)
 (define-list-type 'string)
+(export-always 'list-of-keymaps)
+(define-list-type 'keymap:keymap)
 
 (defun alist-of-strings-p (alist)
   "Return t if ALIST is an alist whose keys and values are strings."


### PR DESCRIPTION
Fixes #117 . 

Previously I mentioned that we could do it by setting an input dispatcher.  I was wrong, because the input dispatcher works at the window level, while here we want something that works at the buffer level.

I think the right place to hi-jack the input at the buffer level is when we collect the keymaps in `current-keymaps`.  Currently, `current-keymaps` takes a window parameter.  I believe it should take a buffer (or minibuffer) parameter.

Thoughts?