### PR TITLE
Search engines

### DIFF
--- a/source/buffer.lisp
+++ b/source/buffer.lisp
@@ -207,14 +207,15 @@ complete against a search engine."
     ;; Complete a search engine name.
     ((and (not (str:emptyp (input-buffer minibuffer)))
           (zerop (completion-cursor minibuffer)))
-     (let* ((engines (mapcar #'first (search-engines *browser*)))
+     (let* ((engines (search-engines *browser*))
             (matching-engines
               (remove-if (complement (alex:curry #'str:starts-with-p (input-buffer minibuffer)))
-                        engines)))
+                         engines
+                         :key #'shortcut)))
        (match (length matching-engines)
          (1
           (kill-whole-line minibuffer)
-          (insert (str:concat (first matching-engines) " ")))
+          (insert (str:concat (shortcut (first matching-engines)) " ")))
          (match-count
           (with-result (engine (read-from-minibuffer
                                 (make-minibuffer
@@ -222,11 +223,10 @@ complete against a search engine."
                                  :input-buffer (if (zerop match-count) "" (input-buffer minibuffer))
                                  :completion-function (lambda (minibuffer)
                                                         (fuzzy-match (input-buffer minibuffer)
-                                                                     engines))
-                                 :empty-complete-immediate t)))
-            (unless (uiop:emptyp engine)
+                                                                     engines)))))
+            (when engine
               (kill-whole-line minibuffer)
-              (insert (str:concat engine " ") minibuffer)))))))
+              (insert (str:concat (shortcut engine) " ") minibuffer)))))))
     (t
      (insert-candidate minibuffer))))
 

--- a/source/types.lisp
+++ b/source/types.lisp
@@ -35,6 +35,8 @@ Example:
 (define-list-type 'keymap:keymap)
 (export-always 'list-of-tags)
 (define-list-type 'tag)
+(export-always 'list-of-search-engines)
+(define-list-type 'search-engine)
 
 (defun alist-of-strings-p (alist)
   "Return t if ALIST is an alist whose keys and values are strings."
@@ -58,33 +60,6 @@ Example:
   (assert (typep '(("rst" . "rst")) 'alist-of-strings))
   (assert (not (typep '() 'alist-of-strings)))
   (assert (not (typep nil 'alist-of-strings))))
-
-(defun alist-of-string+2strings-p (alist)
-  "Return t if ALIST is an association list composed of 3-tuples, made only of strings."
-  (and (trivial-types:association-list-p alist)
-       (every (lambda (it)
-                (and
-                 (= 3 (length it))
-                 (every #'stringp it)))
-              alist)))
-
-(export-always 'alist-of-string+2strings)
-(deftype alist-of-string+2strings ()
-  `(satisfies alist-of-string+2strings-p))
-
-#+doctest
-(progn
-  (assert (typep '(("default" "https://duckduckgo.com/?q=~a" "https://duckduckgo.com/")
-                   ("wiki" "https://en.wikipedia.org/w/index.php?search=~a"
-                    "https://en.wikipedia.org/"))
-                 'alist-of-string+2strings))
-  (assert (not (typep '(("default" "two" "three" "four")
-                        ("wiki" "https://en.wikipedia.org/w/index.php?search=~a"
-                         "https://en.wikipedia.org/"))
-                      'alist-of-string+2strings)))
-  (assert (not (typep '(("default" "two" "three")
-                        ("wiki" :foo "https://en.wikipedia.org/"))
-                      'alist-of-string+2strings))))
 
 (deftype cookie-policy ()
   `(or (eql :always)

--- a/source/urls.lisp
+++ b/source/urls.lisp
@@ -12,12 +12,12 @@
 
 (defun bookmark-search-engines (&optional (bookmarks (bookmarks-data *browser*)))
   (mapcar (lambda (b)
-            (list
-             (shortcut b)
-             (if (quri:uri-scheme (quri:uri (search-url b)))
-                 (search-url b)
-                 (str:concat (url b) (search-url b)))
-             (url b)))
+            (make-instance 'search-engine
+                           :shortcut (shortcut b)
+                           :search-url (if (quri:uri-scheme (quri:uri (search-url b)))
+                                           (search-url b)
+                                           (str:concat (url b) (search-url b)))
+                           :fallback-url (url b)))
           (remove-if (lambda (b) (or (str:emptyp (search-url b))
                                      (str:emptyp (shortcut b))))
                      bookmarks)))
@@ -45,19 +45,17 @@ Otherwise, build a search query with the default search engine."
   (let* ((search-engines (append (search-engines *browser*)
                                  (bookmark-search-engines)))
          (terms (str:split " " input-url :omit-nulls t))
-         (engine (assoc (first terms)
-                        search-engines :test #'string=))
-         (default (assoc "default"
-                         search-engines :test #'string=)))
+         (engine (find (first terms)
+                       search-engines :test #'string= :key #'shortcut))
+         (default (or (find "default"
+                            search-engines :test #'string= :key #'shortcut)
+                      (first search-engines))))
     (if engine
         (let ((new-input (str:join " " (rest terms))))
-          (if (and (listp (rest engine))
+          (if (and (not (str:emptyp (fallback-url engine)))
                    (str:emptyp new-input))
-              (third engine)
-              (generate-search-query new-input
-                                     (if (atom (rest engine))
-                                         (rest engine)
-                                         (second engine)))))
+              (fallback-url engine)
+              (generate-search-query new-input (search-url engine))))
         (let ((recognized-scheme (ignore-errors (quri:uri-scheme (quri:uri input-url)))))
           (cond
             ((str:starts-with? "magnet:" input-url)
@@ -76,7 +74,4 @@ Otherwise, build a search query with the default search engine."
                          (uiop:ensure-absolute-pathname input-url *default-pathname-defaults*))))
             ((valid-url-p (str:concat "https://" input-url))
              (str:concat "https://" input-url))
-            (t (generate-search-query input-url
-                                      (if (atom (rest default))
-                                          (rest default)
-                                          (second default)))))))))
+            (t (generate-search-query input-url (search-url default))))))))


### PR DESCRIPTION
Fixes #729.

While I was at it, we now display the full URL of search-engines when listed in the minibuffer.
Besides, we now fall back to the first search engines when none of them have the "default" shortcut.