### PR TITLE
Correct slight typo in MANUAL.org

### DIFF
--- a/documents/MANUAL.org
+++ b/documents/MANUAL.org
@@ -521,7 +521,7 @@ before running this command."
       (echo "Slynk server started at port ~a" slynk-port)))
 #+end_src
 
-Use like for =SLIME=, substituting =start-slynk= for =start-slime= in Next, and =sly-connect= for =slime-connect= in Emacs.
+Use like for =SLIME=, substituting =start-slynk= for =start-swank= in Next, and =sly-connect= for =slime-connect= in Emacs.
 
 ** Command line parameters and environment
 *** Environment variables


### PR DESCRIPTION
Having just done this for the first time, it took me a minute to realize `start-swank` was meant here instead of `start-slime`. Small correction, but should help make things clearer.